### PR TITLE
feat: поиск объектов метаданных — Quick Pick (#1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,11 @@
         "icon": "$(search)"
       },
       {
+        "command": "v8vscedit.searchMetadata",
+        "title": "1С: Поиск объекта метаданных",
+        "icon": "$(search)"
+      },
+      {
         "command": "v8vscedit.bslAnalyzer.showMenu",
         "title": "BSL Analyzer: Меню"
       },
@@ -219,9 +224,14 @@
           "group": "navigation"
         },
         {
+          "command": "v8vscedit.searchMetadata",
+          "when": "view == v8vsceditTree",
+          "group": "navigation@0"
+        },
+        {
           "command": "v8vscedit.refresh",
           "when": "view == v8vsceditTree",
-          "group": "navigation"
+          "group": "navigation@1"
         }
       ],
       "view/item/context": [
@@ -520,6 +530,13 @@
       }
     ]
   },
+  "keybindings": [
+    {
+      "command": "v8vscedit.searchMetadata",
+      "key": "ctrl+shift+m",
+      "when": "workbenchState != empty"
+    }
+  ],
   "scripts": {
     "vscode:prepublish": "npm run build",
     "build": "webpack --mode production",

--- a/src/CommandRegistry.ts
+++ b/src/CommandRegistry.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { spawn } from 'child_process';
 import { decode } from 'iconv-lite';
-import { MetadataTreeProvider } from './MetadataTreeProvider';
+import { MetadataTreeProvider, MetadataQuickPickItem } from './MetadataTreeProvider';
 import { MetadataNode } from './MetadataNode';
 import { PropertiesViewProvider } from './views/PropertiesViewProvider';
 import { OnecFileSystemProvider } from './OnecFileSystemProvider';
@@ -634,6 +634,49 @@ export function registerCommands(
     );
   }
 
+  // Quick Pick поиск по метаданным (Ctrl+Alt+M)
+  context.subscriptions.push(
+    vscode.commands.registerCommand('v8vscedit.searchMetadata', async () => {
+      const items = provider.getAllMetadataItems();
+      if (items.length === 0) {
+        vscode.window.showInformationMessage('Нет загруженных конфигураций.');
+        return;
+      }
+
+      const picked = await vscode.window.showQuickPick(items, {
+        title: 'Поиск объекта метаданных',
+        placeHolder: 'Введите имя объекта...',
+        matchOnDescription: true,
+        matchOnDetail: true,
+      });
+
+      if (!picked) { return; }
+
+      // Построить путь к XML-файлу объекта
+      const folderName = META_FOLDER_NAMES[picked.metaType];
+      if (!folderName) { return; }
+
+      const xmlPath = path.join(
+        picked.configRoot,
+        folderName,
+        picked.metaName,
+        `${picked.metaName}.xml`
+      );
+
+      if (fs.existsSync(xmlPath)) {
+        const editor = await vscode.window.showTextDocument(
+          vscode.Uri.file(xmlPath),
+          { preview: false }
+        );
+        if (supportService?.isLocked(xmlPath)) {
+          await setEditorReadonly(editor);
+        }
+      } else {
+        vscode.window.showWarningMessage(`Файл не найден: ${xmlPath}`);
+      }
+    })
+  );
+
   // FileSystemWatcher — перестраиваем дерево при изменении Configuration.xml
   const watcher = vscode.workspace.createFileSystemWatcher(
     new vscode.RelativePattern(workspaceFolder, '**/Configuration.xml'),
@@ -897,6 +940,56 @@ function pickMostReadableText(candidates: string[]): string {
  * Подбирает корректный абсолютный путь к env.json.
  * Нужен, чтобы избежать дубля "example/example" при разных корнях workspace.
  */
+/** Маппинг типа объекта → имя папки в XML-выгрузке */
+const META_FOLDER_NAMES: Record<string, string> = {
+  Subsystem: 'Subsystems',
+  CommonModule: 'CommonModules',
+  Role: 'Roles',
+  CommonForm: 'CommonForms',
+  CommonCommand: 'CommonCommands',
+  CommandGroup: 'CommandGroups',
+  CommonPicture: 'CommonPictures',
+  CommonTemplate: 'CommonTemplates',
+  XDTOPackage: 'XDTOPackages',
+  StyleItem: 'StyleItems',
+  DefinedType: 'DefinedTypes',
+  Constant: 'Constants',
+  Catalog: 'Catalogs',
+  Document: 'Documents',
+  DocumentNumerator: 'DocumentNumerators',
+  Enum: 'Enums',
+  InformationRegister: 'InformationRegisters',
+  AccumulationRegister: 'AccumulationRegisters',
+  AccountingRegister: 'AccountingRegisters',
+  CalculationRegister: 'CalculationRegisters',
+  Report: 'Reports',
+  DataProcessor: 'DataProcessors',
+  BusinessProcess: 'BusinessProcesses',
+  Task: 'Tasks',
+  ExchangePlan: 'ExchangePlans',
+  ChartOfCharacteristicTypes: 'ChartsOfCharacteristicTypes',
+  ChartOfAccounts: 'ChartsOfAccounts',
+  ChartOfCalculationTypes: 'ChartsOfCalculationTypes',
+  DocumentJournal: 'DocumentJournals',
+  ScheduledJob: 'ScheduledJobs',
+  EventSubscription: 'EventSubscriptions',
+  HTTPService: 'HTTPServices',
+  WebService: 'WebServices',
+  FilterCriterion: 'FilterCriteria',
+  Sequence: 'Sequences',
+  SessionParameter: 'SessionParameters',
+  CommonAttribute: 'CommonAttributes',
+  FunctionalOption: 'FunctionalOptions',
+  FunctionalOptionsParameter: 'FunctionalOptionsParameters',
+  SettingsStorage: 'SettingsStorages',
+  Style: 'Styles',
+  WSReference: 'WSReferences',
+  WebSocketClient: 'WebSocketClients',
+  IntegrationService: 'IntegrationServices',
+  Bot: 'Bots',
+  ExternalDataSource: 'ExternalDataSources',
+};
+
 function resolveSettingsPath(workspaceRoot: string, extensionRoot: string): string {
   const extensionParent = path.dirname(extensionRoot);
   const extensionGrandParent = path.dirname(extensionParent);

--- a/src/MetadataTreeProvider.ts
+++ b/src/MetadataTreeProvider.ts
@@ -401,5 +401,94 @@ export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNod
     }
     return result;
   }
+
+  /**
+   * Возвращает плоский список всех объектов метаданных для Quick Pick поиска.
+   * Каждый элемент содержит: label (имя), description (тип), detail (конфигурация).
+   */
+  getAllMetadataItems(): MetadataQuickPickItem[] {
+    const items: MetadataQuickPickItem[] = [];
+
+    for (const entry of this.entries) {
+      const configXmlPath = path.join(entry.rootPath, 'Configuration.xml');
+      const info = parseConfigXml(configXmlPath);
+
+      for (const [typeName, names] of info.childObjects) {
+        const kindLabel = TYPE_LABELS[typeName] ?? typeName;
+        for (const name of names) {
+          items.push({
+            label: name,
+            description: kindLabel,
+            detail: info.name,
+            configRoot: entry.rootPath,
+            metaType: typeName,
+            metaName: name,
+          });
+        }
+      }
+    }
+
+    return items;
+  }
 }
+
+/** Элемент Quick Pick с метаданными для навигации */
+export interface MetadataQuickPickItem extends vscode.QuickPickItem {
+  configRoot: string;
+  metaType: string;
+  metaName: string;
+}
+
+/** Человекочитаемые названия типов объектов метаданных */
+const TYPE_LABELS: Record<string, string> = {
+  Subsystem: 'Подсистема',
+  CommonModule: 'Общий модуль',
+  Role: 'Роль',
+  CommonForm: 'Общая форма',
+  CommonCommand: 'Общая команда',
+  CommandGroup: 'Группа команд',
+  CommonPicture: 'Общая картинка',
+  CommonTemplate: 'Общий макет',
+  XDTOPackage: 'XDTO-пакет',
+  StyleItem: 'Элемент стиля',
+  DefinedType: 'Определяемый тип',
+  Constant: 'Константа',
+  Catalog: 'Справочник',
+  Document: 'Документ',
+  DocumentNumerator: 'Нумератор',
+  Enum: 'Перечисление',
+  InformationRegister: 'Регистр сведений',
+  AccumulationRegister: 'Регистр накопления',
+  AccountingRegister: 'Регистр бухгалтерии',
+  CalculationRegister: 'Регистр расчета',
+  Report: 'Отчет',
+  DataProcessor: 'Обработка',
+  BusinessProcess: 'Бизнес-процесс',
+  Task: 'Задача',
+  ExchangePlan: 'План обмена',
+  ChartOfCharacteristicTypes: 'ПВХ',
+  ChartOfAccounts: 'План счетов',
+  ChartOfCalculationTypes: 'ПВР',
+  DocumentJournal: 'Журнал документов',
+  ScheduledJob: 'Рег. задание',
+  EventSubscription: 'Подписка на событие',
+  HTTPService: 'HTTP-сервис',
+  WebService: 'Web-сервис',
+  FilterCriterion: 'Критерий отбора',
+  Sequence: 'Последовательность',
+  SessionParameter: 'Параметр сеанса',
+  CommonAttribute: 'Общий реквизит',
+  FunctionalOption: 'Функц. опция',
+  FunctionalOptionsParameter: 'Параметр функц. опции',
+  SettingsStorage: 'Хранилище настроек',
+  Style: 'Стиль',
+  WSReference: 'WS-ссылка',
+  WebSocketClient: 'WebSocket',
+  IntegrationService: 'Сервис интеграции',
+  Bot: 'Бот',
+  ExternalDataSource: 'Внешний источник',
+  Interface: 'Интерфейс',
+  PaletteColor: 'Цвет палитры',
+  Language: 'Язык',
+};
 


### PR DESCRIPTION
## Summary

- Quick Pick диалог для быстрого поиска и открытия объектов метаданных
- Поиск по имени, типу объекта и имени конфигурации
- Кнопка 🔎 в тулбаре дерева навигатора
- Горячая клавиша Ctrl+Shift+M (как в EDT)
- Открывает XML-файл выбранного объекта

Closes #1

## Test plan

- [ ] `npm run build` — без ошибок
- [ ] Ctrl+Shift+M → появляется Quick Pick с объектами метаданных
- [ ] Ввести имя справочника → находится, выбрать → открывается XML
- [ ] Кнопка поиска в тулбаре дерева → тот же Quick Pick
- [ ] Поиск по типу (ввести "Документ") → фильтрует по description

🤖 Generated with [Claude Code](https://claude.com/claude-code)