### PR TITLE
feat: интеграция с хранилищем конфигурации (#46)

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,30 @@
         "icon": "$(sync)"
       },
       {
+        "command": "v8vscedit.repo.create",
+        "title": "Создать хранилище конфигурации",
+        "icon": "$(add)"
+      },
+      {
+        "command": "v8vscedit.repo.commit",
+        "title": "Поместить в хранилище",
+        "icon": "$(cloud-upload)"
+      },
+      {
+        "command": "v8vscedit.repo.updateCfg",
+        "title": "Получить из хранилища",
+        "icon": "$(cloud-download)"
+      },
+      {
+        "command": "v8vscedit.repo.addUser",
+        "title": "Добавить пользователя хранилища"
+      },
+      {
+        "command": "v8vscedit.repo.history",
+        "title": "История хранилища",
+        "icon": "$(history)"
+      },
+      {
         "command": "v8vscedit.repo.status.free",
         "title": "Свободен в хранилище",
         "icon": {
@@ -277,19 +301,44 @@
           "group": "inline"
         },
         {
-          "command": "v8vscedit.repo.connect",
+          "command": "v8vscedit.repo.create",
           "when": "view == v8vsceditTree && viewItem =~ /^(configuration|extension)-hasXml/ && !(viewItem =~ /-repoConnected/)",
           "group": "repo@0"
         },
         {
-          "command": "v8vscedit.repo.disconnect",
-          "when": "view == v8vsceditTree && viewItem =~ /-repoConnected/",
+          "command": "v8vscedit.repo.connect",
+          "when": "view == v8vsceditTree && viewItem =~ /^(configuration|extension)-hasXml/ && !(viewItem =~ /-repoConnected/)",
           "group": "repo@1"
+        },
+        {
+          "command": "v8vscedit.repo.commit",
+          "when": "view == v8vsceditTree && viewItem =~ /-repoConnected/",
+          "group": "repo@2"
+        },
+        {
+          "command": "v8vscedit.repo.updateCfg",
+          "when": "view == v8vsceditTree && viewItem =~ /-repoConnected/",
+          "group": "repo@3"
         },
         {
           "command": "v8vscedit.repo.refreshLocks",
           "when": "view == v8vsceditTree && viewItem =~ /-repoConnected/",
-          "group": "repo@2"
+          "group": "repo@4"
+        },
+        {
+          "command": "v8vscedit.repo.history",
+          "when": "view == v8vsceditTree && viewItem =~ /-repoConnected/",
+          "group": "repo@5"
+        },
+        {
+          "command": "v8vscedit.repo.addUser",
+          "when": "view == v8vsceditTree && viewItem =~ /-repoConnected/",
+          "group": "repo@6"
+        },
+        {
+          "command": "v8vscedit.repo.disconnect",
+          "when": "view == v8vsceditTree && viewItem =~ /-repoConnected/",
+          "group": "repo@9"
         },
         {
           "command": "v8vscedit.repo.lock",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,52 @@
           "light": "./src/icons/light/support-locked.svg",
           "dark": "./src/icons/dark/support-locked.svg"
         }
+      },
+      {
+        "command": "v8vscedit.repo.connect",
+        "title": "Подключить к хранилищу конфигурации",
+        "icon": "$(link)"
+      },
+      {
+        "command": "v8vscedit.repo.disconnect",
+        "title": "Отключить от хранилища"
+      },
+      {
+        "command": "v8vscedit.repo.lock",
+        "title": "Захватить в хранилище"
+      },
+      {
+        "command": "v8vscedit.repo.unlock",
+        "title": "Снять захват в хранилище"
+      },
+      {
+        "command": "v8vscedit.repo.refreshLocks",
+        "title": "Обновить статус захватов",
+        "icon": "$(sync)"
+      },
+      {
+        "command": "v8vscedit.repo.status.free",
+        "title": "Свободен в хранилище",
+        "icon": {
+          "light": "./src/icons/light/repo-free.svg",
+          "dark": "./src/icons/dark/repo-free.svg"
+        }
+      },
+      {
+        "command": "v8vscedit.repo.status.lockedByMe",
+        "title": "Захвачен мной",
+        "icon": {
+          "light": "./src/icons/light/repo-locked-mine.svg",
+          "dark": "./src/icons/dark/repo-locked-mine.svg"
+        }
+      },
+      {
+        "command": "v8vscedit.repo.status.lockedByOther",
+        "title": "Захвачен другим пользователем",
+        "icon": {
+          "light": "./src/icons/light/repo-locked-other.svg",
+          "dark": "./src/icons/dark/repo-locked-other.svg"
+        }
       }
     ],
     "menus": {
@@ -229,6 +275,46 @@
           "command": "v8vscedit.support.editable",
           "when": "view == v8vsceditTree && viewItem =~ /-support2/",
           "group": "inline"
+        },
+        {
+          "command": "v8vscedit.repo.connect",
+          "when": "view == v8vsceditTree && viewItem =~ /^(configuration|extension)-hasXml/ && !(viewItem =~ /-repoConnected/)",
+          "group": "repo@0"
+        },
+        {
+          "command": "v8vscedit.repo.disconnect",
+          "when": "view == v8vsceditTree && viewItem =~ /-repoConnected/",
+          "group": "repo@1"
+        },
+        {
+          "command": "v8vscedit.repo.refreshLocks",
+          "when": "view == v8vsceditTree && viewItem =~ /-repoConnected/",
+          "group": "repo@2"
+        },
+        {
+          "command": "v8vscedit.repo.lock",
+          "when": "view == v8vsceditTree && viewItem =~ /-repoFree/",
+          "group": "repo@0"
+        },
+        {
+          "command": "v8vscedit.repo.unlock",
+          "when": "view == v8vsceditTree && viewItem =~ /-repoLockedByMe/",
+          "group": "repo@1"
+        },
+        {
+          "command": "v8vscedit.repo.status.free",
+          "when": "view == v8vsceditTree && viewItem =~ /-repoFree/",
+          "group": "inline"
+        },
+        {
+          "command": "v8vscedit.repo.status.lockedByMe",
+          "when": "view == v8vsceditTree && viewItem =~ /-repoLockedByMe/",
+          "group": "inline"
+        },
+        {
+          "command": "v8vscedit.repo.status.lockedByOther",
+          "when": "view == v8vsceditTree && viewItem =~ /-repoLockedByOther/",
+          "group": "inline"
         }
       ]
     },
@@ -301,6 +387,12 @@
           "type": "string",
           "default": "",
           "description": "Путь к исполняемому файлу bsl-analyzer (если пусто — скачивается автоматически)"
+        },
+        "v8vscedit.repository.connections": {
+          "type": "object",
+          "default": {},
+          "description": "Настройки подключения к хранилищам конфигурации 1С (по корню конфигурации)",
+          "scope": "window"
         }
       }
     },

--- a/src/CommandRegistry.ts
+++ b/src/CommandRegistry.ts
@@ -9,6 +9,8 @@ import { PropertiesViewProvider } from './views/PropertiesViewProvider';
 import { OnecFileSystemProvider } from './OnecFileSystemProvider';
 import { buildVirtualUri, buildFormModuleVirtualUri } from './OnecUriBuilder';
 import { SupportInfoService } from './services/SupportInfoService';
+import { RepoConnectionService } from './services/RepoConnectionService';
+import { RepoLockService } from './services/RepoLockService';
 import {
   getCommonCommandModulePath,
   getCommonFormModulePath,
@@ -84,7 +86,9 @@ export function registerCommands(
   propertiesViewProvider: PropertiesViewProvider,
   fsp: OnecFileSystemProvider,
   outputChannel: vscode.OutputChannel,
-  supportService?: SupportInfoService
+  supportService?: SupportInfoService,
+  repoConnectionService?: RepoConnectionService,
+  repoLockService?: RepoLockService
 ): void {
   // Открыть XML-файл объекта метаданных
   context.subscriptions.push(
@@ -356,6 +360,121 @@ export function registerCommands(
     })
   );
 
+  // ── Команды хранилища конфигурации ──────────────────────────────────────
+  if (repoConnectionService && repoLockService) {
+    // Подключить к хранилищу
+    context.subscriptions.push(
+      vscode.commands.registerCommand('v8vscedit.repo.connect', async (node: NodeArg) => {
+        const configRoot = extractConfigRoot(node);
+        if (!configRoot) { return; }
+
+        const settings = await repoConnectionService.promptAndSaveSettings(configRoot);
+        if (!settings) { return; }
+
+        await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Window, title: 'Обновление захватов хранилища...' },
+          async () => {
+            await repoLockService.refreshLocks(configRoot);
+            provider.refresh();
+          }
+        );
+
+        vscode.window.showInformationMessage('Хранилище подключено. Статус захватов обновлён.');
+      })
+    );
+
+    // Отключить от хранилища
+    context.subscriptions.push(
+      vscode.commands.registerCommand('v8vscedit.repo.disconnect', async (node: NodeArg) => {
+        const configRoot = extractConfigRoot(node);
+        if (!configRoot) { return; }
+
+        await repoConnectionService.removeSettings(configRoot);
+        repoLockService.invalidate(configRoot);
+        provider.refresh();
+        vscode.window.showInformationMessage('Хранилище отключено.');
+      })
+    );
+
+    // Захватить объект
+    context.subscriptions.push(
+      vscode.commands.registerCommand('v8vscedit.repo.lock', async (node: NodeArg) => {
+        const metaNode = node as MetadataNode;
+        const configRoot = metaNode.configRoot;
+        if (!configRoot || !metaNode.nodeKind || !metaNode.label) { return; }
+
+        const label = String(metaNode.label);
+        const confirmed = await vscode.window.showInformationMessage(
+          `Захватить "${label}" в хранилище?`,
+          { modal: true },
+          'Захватить'
+        );
+        if (confirmed !== 'Захватить') { return; }
+
+        const success = await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Window, title: `Захват: ${label}...` },
+          () => repoLockService.lockObject(configRoot, metaNode.nodeKind, label)
+        );
+
+        if (success) {
+          provider.refresh();
+          vscode.window.showInformationMessage(`"${label}" захвачен.`);
+        } else {
+          vscode.window.showErrorMessage(`Не удалось захватить "${label}". Подробности в канале вывода.`);
+        }
+      })
+    );
+
+    // Снять захват
+    context.subscriptions.push(
+      vscode.commands.registerCommand('v8vscedit.repo.unlock', async (node: NodeArg) => {
+        const metaNode = node as MetadataNode;
+        const configRoot = metaNode.configRoot;
+        if (!configRoot || !metaNode.nodeKind || !metaNode.label) { return; }
+
+        const label = String(metaNode.label);
+        const confirmed = await vscode.window.showInformationMessage(
+          `Снять захват "${label}" в хранилище?`,
+          { modal: true },
+          'Снять захват'
+        );
+        if (confirmed !== 'Снять захват') { return; }
+
+        const success = await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Window, title: `Снятие захвата: ${label}...` },
+          () => repoLockService.unlockObject(configRoot, metaNode.nodeKind, label)
+        );
+
+        if (success) {
+          provider.refresh();
+          vscode.window.showInformationMessage(`Захват "${label}" снят.`);
+        } else {
+          vscode.window.showErrorMessage(`Не удалось снять захват "${label}". Подробности в канале вывода.`);
+        }
+      })
+    );
+
+    // Обновить статус захватов
+    context.subscriptions.push(
+      vscode.commands.registerCommand('v8vscedit.repo.refreshLocks', async (node: NodeArg) => {
+        const configRoot = extractConfigRoot(node);
+        if (!configRoot) { return; }
+
+        const success = await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Window, title: 'Обновление захватов хранилища...' },
+          () => repoLockService.refreshLocks(configRoot)
+        );
+
+        if (success) {
+          provider.refresh();
+          vscode.window.showInformationMessage('Статус захватов обновлён.');
+        } else {
+          vscode.window.showErrorMessage('Не удалось получить отчёт из хранилища. Подробности в канале вывода.');
+        }
+      })
+    );
+  }
+
   // FileSystemWatcher — перестраиваем дерево при изменении Configuration.xml
   const watcher = vscode.workspace.createFileSystemWatcher(
     new vscode.RelativePattern(workspaceFolder, '**/Configuration.xml'),
@@ -546,6 +665,14 @@ async function runVrunnerExtensionCommand(
     await vscode.window.showErrorMessage(`${options.errorTitle}\n${message}`, { modal: true });
     return false;
   }
+}
+
+function extractConfigRoot(node: NodeArg): string | null {
+  const metaNode = node as MetadataNode;
+  if (metaNode.configRoot) { return metaNode.configRoot; }
+  const xmlPath = node?.xmlPath;
+  if (!xmlPath) { return null; }
+  return path.dirname(xmlPath);
 }
 
 function extractExtensionTarget(node: NodeArg): { extensionName: string; extensionRoot: string } | null {

--- a/src/CommandRegistry.ts
+++ b/src/CommandRegistry.ts
@@ -473,6 +473,165 @@ export function registerCommands(
         }
       })
     );
+
+    // Создать хранилище
+    context.subscriptions.push(
+      vscode.commands.registerCommand('v8vscedit.repo.create', async (node: NodeArg) => {
+        const configRoot = extractConfigRoot(node);
+        if (!configRoot) { return; }
+
+        if (!repoConnectionService.hasSettings(configRoot)) {
+          const settings = await repoConnectionService.promptAndSaveSettings(configRoot);
+          if (!settings) { return; }
+        }
+
+        const confirmed = await vscode.window.showWarningMessage(
+          'Создать новое хранилище конфигурации? Текущая конфигурация базы будет помещена как начальная версия.',
+          { modal: true },
+          'Создать'
+        );
+        if (confirmed !== 'Создать') { return; }
+
+        const success = await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Window, title: 'Создание хранилища...' },
+          () => repoLockService.createRepository(configRoot)
+        );
+
+        if (success) {
+          provider.refresh();
+          vscode.window.showInformationMessage('Хранилище конфигурации создано.');
+        } else {
+          vscode.window.showErrorMessage('Не удалось создать хранилище. Подробности в канале вывода.');
+        }
+      })
+    );
+
+    // Поместить в хранилище (commit)
+    context.subscriptions.push(
+      vscode.commands.registerCommand('v8vscedit.repo.commit', async (node: NodeArg) => {
+        const configRoot = extractConfigRoot(node);
+        if (!configRoot) { return; }
+
+        const comment = await vscode.window.showInputBox({
+          title: 'Помещение в хранилище',
+          prompt: 'Комментарий к версии (необязательно)',
+          placeHolder: 'Описание изменений...',
+          ignoreFocusOut: true,
+        });
+        if (comment === undefined) { return; }
+
+        const success = await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Window, title: 'Помещение в хранилище...' },
+          () => repoLockService.commitToRepository(configRoot, comment || undefined)
+        );
+
+        if (success) {
+          await repoLockService.refreshLocks(configRoot);
+          provider.refresh();
+          vscode.window.showInformationMessage('Изменения помещены в хранилище.');
+        } else {
+          vscode.window.showErrorMessage('Не удалось поместить в хранилище. Подробности в канале вывода.');
+        }
+      })
+    );
+
+    // Получить из хранилища (update)
+    context.subscriptions.push(
+      vscode.commands.registerCommand('v8vscedit.repo.updateCfg', async (node: NodeArg) => {
+        const configRoot = extractConfigRoot(node);
+        if (!configRoot) { return; }
+
+        const confirmed = await vscode.window.showInformationMessage(
+          'Получить конфигурацию из хранилища? Текущая конфигурация БД будет обновлена.',
+          { modal: true },
+          'Получить'
+        );
+        if (confirmed !== 'Получить') { return; }
+
+        const success = await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Window, title: 'Получение из хранилища...' },
+          () => repoLockService.updateFromRepository(configRoot)
+        );
+
+        if (success) {
+          await repoLockService.refreshLocks(configRoot);
+          provider.refresh();
+          vscode.window.showInformationMessage('Конфигурация обновлена из хранилища.');
+        } else {
+          vscode.window.showErrorMessage('Не удалось получить из хранилища. Подробности в канале вывода.');
+        }
+      })
+    );
+
+    // Добавить пользователя хранилища
+    context.subscriptions.push(
+      vscode.commands.registerCommand('v8vscedit.repo.addUser', async (node: NodeArg) => {
+        const configRoot = extractConfigRoot(node);
+        if (!configRoot) { return; }
+
+        const userName = await vscode.window.showInputBox({
+          title: 'Добавление пользователя хранилища',
+          prompt: 'Имя нового пользователя',
+          ignoreFocusOut: true,
+        });
+        if (!userName) { return; }
+
+        const userPassword = await vscode.window.showInputBox({
+          title: 'Добавление пользователя хранилища',
+          prompt: `Пароль для "${userName}"`,
+          password: true,
+          ignoreFocusOut: true,
+        });
+        if (userPassword === undefined) { return; }
+
+        interface RightsItem extends vscode.QuickPickItem { rightsId: 'ReadOnly' | 'LockObjects' | 'ManageConfigurationVersions' | 'Administration'; }
+        const rightsOptions: RightsItem[] = [
+          { label: 'Захват объектов', description: 'LockObjects', rightsId: 'LockObjects' },
+          { label: 'Только чтение', description: 'ReadOnly', rightsId: 'ReadOnly' },
+          { label: 'Управление версиями', description: 'ManageConfigurationVersions', rightsId: 'ManageConfigurationVersions' },
+          { label: 'Администрирование', description: 'Administration', rightsId: 'Administration' },
+        ];
+        const pickedRights = await vscode.window.showQuickPick(rightsOptions, {
+          title: 'Права пользователя',
+          placeHolder: 'Выберите уровень прав',
+        });
+        if (!pickedRights) { return; }
+
+        const success = await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Window, title: `Добавление пользователя "${userName}"...` },
+          () => repoLockService.addUser(configRoot, userName, userPassword, pickedRights.rightsId)
+        );
+
+        if (success) {
+          vscode.window.showInformationMessage(`Пользователь "${userName}" добавлен в хранилище.`);
+        } else {
+          vscode.window.showErrorMessage(`Не удалось добавить пользователя. Подробности в канале вывода.`);
+        }
+      })
+    );
+
+    // История хранилища
+    context.subscriptions.push(
+      vscode.commands.registerCommand('v8vscedit.repo.history', async (node: NodeArg) => {
+        const configRoot = extractConfigRoot(node);
+        if (!configRoot) { return; }
+
+        const report = await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Window, title: 'Получение истории хранилища...' },
+          () => repoLockService.getHistory(configRoot)
+        );
+
+        if (report) {
+          const doc = await vscode.workspace.openTextDocument({
+            content: report,
+            language: 'plaintext',
+          });
+          await vscode.window.showTextDocument(doc, { preview: true });
+        } else {
+          vscode.window.showErrorMessage('Не удалось получить историю хранилища. Подробности в канале вывода.');
+        }
+      })
+    );
   }
 
   // FileSystemWatcher — перестраиваем дерево при изменении Configuration.xml

--- a/src/MetadataNode.ts
+++ b/src/MetadataNode.ts
@@ -168,6 +168,9 @@ export function getNodeKindLabel(nodeKind: NodeKind): string {
 
 /** Узел дерева метаданных */
 export class MetadataNode extends vscode.TreeItem {
+  /** Корневой путь конфигурации (каталог с Configuration.xml) */
+  public configRoot?: string;
+
   constructor(
     /** Отображаемая метка */
     public readonly label: string,

--- a/src/MetadataTreeProvider.ts
+++ b/src/MetadataTreeProvider.ts
@@ -9,6 +9,7 @@ import { buildNode } from './nodes/_base';
 import { getNodeDescriptor } from './nodes';
 import { getObjectHandler } from './handlers';
 import { SupportInfoService, SupportMode } from './services/SupportInfoService';
+import { RepoLockService, RepoLockStatus } from './services/RepoLockService';
 
 export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNode> {
   private _onDidChangeTreeData = new vscode.EventEmitter<MetadataNode | undefined | null>();
@@ -19,7 +20,8 @@ export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNod
   constructor(
     private entries: ConfigEntry[],
     private readonly extensionUri: vscode.Uri,
-    private readonly supportService?: SupportInfoService
+    private readonly supportService?: SupportInfoService,
+    private readonly repoLockService?: RepoLockService
   ) {
     this.buildRoots();
   }
@@ -39,6 +41,7 @@ export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNod
   getTreeItem(element: MetadataNode): vscode.TreeItem {
     element.iconPath = getIconUris(element.nodeKind, element.ownershipTag, this.extensionUri);
     this.applySupportDecoration(element);
+    this.applyRepoLockDecoration(element);
     return element;
   }
 
@@ -57,6 +60,54 @@ export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNod
     // Суффикс contextValue для показа inline-иконки при наведении
     const baseCtx = (element.contextValue ?? '').replace(/-support\d$/, '');
     element.contextValue = `${baseCtx}-support${mode}`;
+  }
+
+  /**
+   * Добавляет к contextValue суффикс статуса захвата в хранилище:
+   * `-repoFree`, `-repoLockedByMe`, `-repoLockedByOther`.
+   * Для корневого узла конфигурации добавляет `-repoConnected`.
+   */
+  private applyRepoLockDecoration(element: MetadataNode): void {
+    if (!this.repoLockService) { return; }
+
+    const configRoot = element.configRoot;
+    if (!configRoot) { return; }
+
+    // Для корневого узла конфигурации — только маркер подключения
+    if (element.nodeKind === 'configuration' || element.nodeKind === 'extension') {
+      if (this.repoLockService.isConnected(configRoot)) {
+        element.contextValue = `${element.contextValue ?? ''}-repoConnected`;
+      }
+      return;
+    }
+
+    // Для объектов метаданных — статус захвата
+    if (!this.repoLockService.isConnected(configRoot)) { return; }
+    if (!this.repoLockService.hasLockData(configRoot)) { return; }
+    if (!this.repoLockService.isLockable(element.nodeKind)) { return; }
+
+    const label = typeof element.label === 'string' ? element.label : '';
+    const status = this.repoLockService.getLockStatus(configRoot, element.nodeKind, label);
+
+    let suffix: string;
+    switch (status) {
+      case RepoLockStatus.LockedByMe:
+        suffix = '-repoLockedByMe';
+        break;
+      case RepoLockStatus.LockedByOther:
+        suffix = '-repoLockedByOther';
+        break;
+      default:
+        suffix = '-repoFree';
+        break;
+    }
+
+    const info = this.repoLockService.getLockInfo(configRoot, element.nodeKind, label);
+    if (info?.lockedBy) {
+      element.tooltip = `${element.tooltip ?? label}\nЗахвачен: ${info.lockedBy}`;
+    }
+
+    element.contextValue = `${element.contextValue ?? ''}${suffix}`;
   }
 
   getChildren(element?: MetadataNode): MetadataNode[] {
@@ -115,6 +166,7 @@ export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNod
       childrenLoader: () => this.buildConfigChildren(entry, info),
       ownershipTag: undefined,
     });
+    node.configRoot = entry.rootPath;
 
     if (info.synonym) {
       node.tooltip = info.synonym;
@@ -170,7 +222,7 @@ export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNod
               );
             }
           }
-          mergedChildren = parts;
+          mergedChildren = this.tagConfigRoot(parts, entry.rootPath);
         }
       }
 
@@ -188,14 +240,17 @@ export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNod
           xmlPath: undefined,
           childrenLoader: hasChildren
             ? () =>
-                mergeTypes && mergedChildren
-                  ? mergedChildren
-                  : handler!.buildTreeNodes({
-                      configRoot: entry.rootPath,
-                      configKind: entry.kind,
-                      namePrefix: info.namePrefix,
-                      names,
-                    })
+                this.tagConfigRoot(
+                  mergeTypes && mergedChildren
+                    ? mergedChildren
+                    : handler!.buildTreeNodes({
+                        configRoot: entry.rootPath,
+                        configKind: entry.kind,
+                        namePrefix: info.namePrefix,
+                        names,
+                      }),
+                  entry.rootPath
+                )
             : undefined,
           ownershipTag: undefined,
         })
@@ -228,12 +283,15 @@ export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNod
         xmlPath: undefined,
         childrenLoader: hasNum
           ? () =>
-              numHandler!.buildTreeNodes({
-                configRoot: entry.rootPath,
-                configKind: entry.kind,
-                namePrefix: info.namePrefix,
-                names: numNames,
-              })
+              this.tagConfigRoot(
+                numHandler!.buildTreeNodes({
+                  configRoot: entry.rootPath,
+                  configKind: entry.kind,
+                  namePrefix: info.namePrefix,
+                  names: numNames,
+                }),
+                entry.rootPath
+              )
           : undefined,
         ownershipTag: undefined,
         hidePropertiesCommand: true,
@@ -253,12 +311,15 @@ export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNod
         xmlPath: undefined,
         childrenLoader: hasSeq
           ? () =>
-              seqHandler!.buildTreeNodes({
-                configRoot: entry.rootPath,
-                configKind: entry.kind,
-                namePrefix: info.namePrefix,
-                names: seqNames,
-              })
+              this.tagConfigRoot(
+                seqHandler!.buildTreeNodes({
+                  configRoot: entry.rootPath,
+                  configKind: entry.kind,
+                  namePrefix: info.namePrefix,
+                  names: seqNames,
+                }),
+                entry.rootPath
+              )
           : undefined,
         ownershipTag: undefined,
         hidePropertiesCommand: true,
@@ -268,12 +329,15 @@ export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNod
     const docHandler = getObjectHandler('Document');
     if (docHandler && docNames.length > 0) {
       children.push(
-        ...docHandler.buildTreeNodes({
-          configRoot: entry.rootPath,
-          configKind: entry.kind,
-          namePrefix: info.namePrefix,
-          names: docNames,
-        })
+        ...this.tagConfigRoot(
+          docHandler.buildTreeNodes({
+            configRoot: entry.rootPath,
+            configKind: entry.kind,
+            namePrefix: info.namePrefix,
+            names: docNames,
+          }),
+          entry.rootPath
+        )
       );
     }
 
@@ -297,16 +361,25 @@ export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNod
         xmlPath: undefined,
         childrenLoader: hasChildren
           ? () =>
-              handler!.buildTreeNodes({
-                configRoot: entry.rootPath,
-                configKind: entry.kind,
-                namePrefix: info.namePrefix,
-                names,
-              })
+              this.tagConfigRoot(
+                handler!.buildTreeNodes({
+                  configRoot: entry.rootPath,
+                  configKind: entry.kind,
+                  namePrefix: info.namePrefix,
+                  names,
+                }),
+                entry.rootPath
+              )
           : undefined,
         ownershipTag: undefined,
       });
     });
+  }
+
+  /** Проставляет configRoot на массиве узлов и возвращает его */
+  private tagConfigRoot(nodes: MetadataNode[], configRoot: string): MetadataNode[] {
+    for (const n of nodes) { n.configRoot = configRoot; }
+    return nodes;
   }
 
   /** Собирает имена объектов по нескольким типам из ChildObjects */

--- a/src/MetadataTreeProvider.ts
+++ b/src/MetadataTreeProvider.ts
@@ -73,20 +73,31 @@ export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNod
     const configRoot = element.configRoot;
     if (!configRoot) { return; }
 
+    const baseCtx = (element.contextValue ?? '')
+      .replace(/-repo(?:Connected|Free|LockedByMe|LockedByOther)/g, '');
+    const label = typeof element.label === 'string' ? element.label : '';
+    const baseTooltip = typeof element.tooltip === 'string'
+      ? element.tooltip.replace(/\r?\nЗахвачен:.*$/u, '')
+      : element.tooltip;
+
     // Для корневого узла конфигурации — только маркер подключения
     if (element.nodeKind === 'configuration' || element.nodeKind === 'extension') {
       if (this.repoLockService.isConnected(configRoot)) {
-        element.contextValue = `${element.contextValue ?? ''}-repoConnected`;
+        element.contextValue = `${baseCtx}-repoConnected`;
+      } else {
+        element.contextValue = baseCtx;
       }
       return;
     }
 
     // Для объектов метаданных — статус захвата
+    element.contextValue = baseCtx;
+    element.tooltip = baseTooltip;
+
     if (!this.repoLockService.isConnected(configRoot)) { return; }
     if (!this.repoLockService.hasLockData(configRoot)) { return; }
     if (!this.repoLockService.isLockable(element.nodeKind)) { return; }
 
-    const label = typeof element.label === 'string' ? element.label : '';
     const status = this.repoLockService.getLockStatus(configRoot, element.nodeKind, label);
 
     let suffix: string;
@@ -104,10 +115,10 @@ export class MetadataTreeProvider implements vscode.TreeDataProvider<MetadataNod
 
     const info = this.repoLockService.getLockInfo(configRoot, element.nodeKind, label);
     if (info?.lockedBy) {
-      element.tooltip = `${element.tooltip ?? label}\nЗахвачен: ${info.lockedBy}`;
+      element.tooltip = `${typeof baseTooltip === 'string' ? baseTooltip : label}\nЗахвачен: ${info.lockedBy}`;
     }
 
-    element.contextValue = `${element.contextValue ?? ''}${suffix}`;
+    element.contextValue = `${baseCtx}${suffix}`;
   }
 
   getChildren(element?: MetadataNode): MetadataNode[] {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,8 @@ import { OnecFileSystemProvider, ONEC_SCHEME } from './OnecFileSystemProvider';
 import { SupportInfoService } from './services/SupportInfoService';
 import { SupportDecorationProvider } from './services/SupportDecorationProvider';
 import { LspManager } from './services/LspManager';
+import { RepoConnectionService } from './services/RepoConnectionService';
+import { RepoLockService } from './services/RepoLockService';
 
 let lspManager: LspManager | undefined;
 
@@ -73,8 +75,12 @@ export function activate(context: vscode.ExtensionContext): void {
     })
   );
 
+  // ── Сервис хранилища конфигурации ────────────────────────────────────────
+  const repoConnectionService = new RepoConnectionService(context.secrets);
+  const repoLockService = new RepoLockService(repoConnectionService, outputChannel);
+
   // ── Навигатор метаданных ────────────────────────────────────────────────
-  const provider = new MetadataTreeProvider([], context.extensionUri, supportService);
+  const provider = new MetadataTreeProvider([], context.extensionUri, supportService, repoLockService);
   const propertiesViewProvider = new PropertiesViewProvider();
   context.subscriptions.push(propertiesViewProvider);
 
@@ -99,7 +105,9 @@ export function activate(context: vscode.ExtensionContext): void {
     propertiesViewProvider,
     fsp,
     outputChannel,
-    supportService
+    supportService,
+    repoConnectionService,
+    repoLockService
   );
 
   // ── Readonly для BSL-файлов, открытых напрямую из ФС (схема file://) ───
@@ -138,6 +146,23 @@ export function activate(context: vscode.ExtensionContext): void {
     }),
     vscode.commands.registerCommand('v8vscedit.support.locked', () => {
       vscode.window.showWarningMessage('Объект на поддержке. Редактирование запрещено.');
+    }),
+  );
+
+  // Команды-индикаторы хранилища (inline-кнопки в дереве)
+  context.subscriptions.push(
+    vscode.commands.registerCommand('v8vscedit.repo.status.free', () => {
+      vscode.window.showInformationMessage('Объект свободен в хранилище.');
+    }),
+    vscode.commands.registerCommand('v8vscedit.repo.status.lockedByMe', () => {
+      vscode.window.showInformationMessage('Объект захвачен вами.');
+    }),
+    vscode.commands.registerCommand('v8vscedit.repo.status.lockedByOther', (node: any) => {
+      const info = node?.configRoot
+        ? repoLockService.getLockInfo(node.configRoot, node.nodeKind, String(node.label ?? ''))
+        : undefined;
+      const who = info?.lockedBy ? ` пользователем "${info.lockedBy}"` : '';
+      vscode.window.showWarningMessage(`Объект захвачен${who} в хранилище.`);
     }),
   );
 

--- a/src/icons/dark/repo-free.svg
+++ b/src/icons/dark/repo-free.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <!-- Зелёный фон -->
+  <rect x="2" y="2" width="12" height="12" rx="3" fill="#388A34"/>
+  <!-- Открытый замок (дужка приподнята) -->
+  <path d="M5.5 9 L5.5 7.2 A2.5 2.5 0 0 1 10.5 7.2 L10.5 6"
+        fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Корпус замка -->
+  <rect x="4.5" y="9" width="7" height="4.5" rx="1" fill="white"/>
+  <!-- Замочная скважина -->
+  <circle cx="8" cy="10.6" r="1" fill="#388A34"/>
+  <rect x="7.35" y="11.2" width="1.3" height="1.5" fill="#388A34"/>
+</svg>

--- a/src/icons/dark/repo-locked-mine.svg
+++ b/src/icons/dark/repo-locked-mine.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <!-- Синий фон -->
+  <rect x="2" y="2" width="12" height="12" rx="3" fill="#1976D2"/>
+  <!-- Закрытый замок (дужка на месте) -->
+  <path d="M5.5 9 L5.5 7.2 A2.5 2.5 0 0 1 10.5 7.2 L10.5 9"
+        fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Корпус замка -->
+  <rect x="4.5" y="9" width="7" height="4.5" rx="1" fill="white"/>
+  <!-- Замочная скважина -->
+  <circle cx="8" cy="10.6" r="1" fill="#1976D2"/>
+  <rect x="7.35" y="11.2" width="1.3" height="1.5" fill="#1976D2"/>
+</svg>

--- a/src/icons/dark/repo-locked-other.svg
+++ b/src/icons/dark/repo-locked-other.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <!-- Красный фон -->
+  <rect x="2" y="2" width="12" height="12" rx="3" fill="#D32F2F"/>
+  <!-- Закрытый замок (дужка на месте) -->
+  <path d="M5.5 9 L5.5 7.2 A2.5 2.5 0 0 1 10.5 7.2 L10.5 9"
+        fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Корпус замка -->
+  <rect x="4.5" y="9" width="7" height="4.5" rx="1" fill="white"/>
+  <!-- Замочная скважина -->
+  <circle cx="8" cy="10.6" r="1" fill="#D32F2F"/>
+  <rect x="7.35" y="11.2" width="1.3" height="1.5" fill="#D32F2F"/>
+</svg>

--- a/src/icons/light/repo-free.svg
+++ b/src/icons/light/repo-free.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <!-- Зелёный фон -->
+  <rect x="2" y="2" width="12" height="12" rx="3" fill="#2E7D32"/>
+  <!-- Открытый замок -->
+  <path d="M5.5 9 L5.5 7.2 A2.5 2.5 0 0 1 10.5 7.2 L10.5 6"
+        fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <rect x="4.5" y="9" width="7" height="4.5" rx="1" fill="white"/>
+  <circle cx="8" cy="10.6" r="1" fill="#2E7D32"/>
+  <rect x="7.35" y="11.2" width="1.3" height="1.5" fill="#2E7D32"/>
+</svg>

--- a/src/icons/light/repo-locked-mine.svg
+++ b/src/icons/light/repo-locked-mine.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <!-- Синий фон -->
+  <rect x="2" y="2" width="12" height="12" rx="3" fill="#1565C0"/>
+  <!-- Закрытый замок -->
+  <path d="M5.5 9 L5.5 7.2 A2.5 2.5 0 0 1 10.5 7.2 L10.5 9"
+        fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <rect x="4.5" y="9" width="7" height="4.5" rx="1" fill="white"/>
+  <circle cx="8" cy="10.6" r="1" fill="#1565C0"/>
+  <rect x="7.35" y="11.2" width="1.3" height="1.5" fill="#1565C0"/>
+</svg>

--- a/src/icons/light/repo-locked-other.svg
+++ b/src/icons/light/repo-locked-other.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <!-- Красный фон -->
+  <rect x="2" y="2" width="12" height="12" rx="3" fill="#C62828"/>
+  <!-- Закрытый замок -->
+  <path d="M5.5 9 L5.5 7.2 A2.5 2.5 0 0 1 10.5 7.2 L10.5 9"
+        fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <rect x="4.5" y="9" width="7" height="4.5" rx="1" fill="white"/>
+  <circle cx="8" cy="10.6" r="1" fill="#C62828"/>
+  <rect x="7.35" y="11.2" width="1.3" height="1.5" fill="#C62828"/>
+</svg>

--- a/src/services/RepoConnectionService.ts
+++ b/src/services/RepoConnectionService.ts
@@ -54,6 +54,7 @@ export class RepoConnectionService {
   /** Запрашивает у пользователя настройки и сохраняет их */
   async promptAndSaveSettings(configRoot: string): Promise<RepoConnectionSettings | undefined> {
     const existing = this.getSettings(configRoot);
+    const existingPassword = existing ? await this.getPassword(configRoot) : '';
 
     const v8Path = await vscode.window.showInputBox({
       title: 'Путь к 1cv8.exe',
@@ -89,7 +90,9 @@ export class RepoConnectionService {
 
     const password = await vscode.window.showInputBox({
       title: 'Пароль хранилища',
-      prompt: 'Пароль для подключения к хранилищу',
+      prompt: existingPassword
+        ? 'Пароль для подключения к хранилищу (оставьте пустым, чтобы сохранить текущий)'
+        : 'Пароль для подключения к хранилищу',
       password: true,
       ignoreFocusOut: true,
     });
@@ -100,7 +103,9 @@ export class RepoConnectionService {
     const all = this.getAllSettings();
     all[configRoot] = settings;
     await this.saveAllSettings(all);
-    await this.secrets.store(PASSWORD_KEY_PREFIX + configRoot, password);
+    if (password !== '' || !existingPassword) {
+      await this.secrets.store(PASSWORD_KEY_PREFIX + configRoot, password);
+    }
 
     return settings;
   }

--- a/src/services/RepoConnectionService.ts
+++ b/src/services/RepoConnectionService.ts
@@ -1,0 +1,117 @@
+import * as vscode from 'vscode';
+
+export interface RepoConnectionSettings {
+  /** Путь к хранилищу (файловый путь или tcp://host:port/repo) */
+  repoPath: string;
+  /** Имя пользователя хранилища */
+  user: string;
+  /** Путь к файловой базе данных 1С */
+  dbPath: string;
+  /** Путь к 1cv8.exe */
+  v8Path: string;
+}
+
+const SETTINGS_SECTION = 'v8vscedit.repository';
+const PASSWORD_KEY_PREFIX = 'v8vscedit.repo.password.';
+
+export class RepoConnectionService {
+  constructor(private readonly secrets: vscode.SecretStorage) {}
+
+  /** Проверяет, есть ли сохранённые настройки для данного корня конфигурации */
+  hasSettings(configRoot: string): boolean {
+    const all = this.getAllSettings();
+    return configRoot in all;
+  }
+
+  /** Получает настройки подключения (без пароля — он в SecretStorage) */
+  getSettings(configRoot: string): RepoConnectionSettings | undefined {
+    const all = this.getAllSettings();
+    const raw = all[configRoot];
+    if (!raw || !raw.repoPath) {
+      return undefined;
+    }
+    return {
+      repoPath: raw.repoPath ?? '',
+      user: raw.user ?? '',
+      dbPath: raw.dbPath ?? '',
+      v8Path: raw.v8Path ?? '',
+    };
+  }
+
+  /** Получает пароль из SecretStorage */
+  async getPassword(configRoot: string): Promise<string> {
+    return (await this.secrets.get(PASSWORD_KEY_PREFIX + configRoot)) ?? '';
+  }
+
+  /** Удаляет настройки подключения */
+  async removeSettings(configRoot: string): Promise<void> {
+    const all = this.getAllSettings();
+    delete all[configRoot];
+    await this.saveAllSettings(all);
+    await this.secrets.delete(PASSWORD_KEY_PREFIX + configRoot);
+  }
+
+  /** Запрашивает у пользователя настройки и сохраняет их */
+  async promptAndSaveSettings(configRoot: string): Promise<RepoConnectionSettings | undefined> {
+    const existing = this.getSettings(configRoot);
+
+    const v8Path = await vscode.window.showInputBox({
+      title: 'Путь к 1cv8.exe',
+      prompt: 'Укажите полный путь к исполняемому файлу 1cv8.exe',
+      value: existing?.v8Path ?? 'C:\\Program Files\\1cv8\\8.3.24.1819\\bin\\1cv8.exe',
+      ignoreFocusOut: true,
+    });
+    if (v8Path === undefined) { return undefined; }
+
+    const dbPath = await vscode.window.showInputBox({
+      title: 'Путь к базе данных',
+      prompt: 'Укажите путь к файловой базе данных 1С',
+      value: existing?.dbPath ?? '',
+      ignoreFocusOut: true,
+    });
+    if (dbPath === undefined) { return undefined; }
+
+    const repoPath = await vscode.window.showInputBox({
+      title: 'Путь к хранилищу',
+      prompt: 'Файловый путь или tcp://host:port/repo',
+      value: existing?.repoPath ?? '',
+      ignoreFocusOut: true,
+    });
+    if (repoPath === undefined) { return undefined; }
+
+    const user = await vscode.window.showInputBox({
+      title: 'Пользователь хранилища',
+      prompt: 'Имя пользователя для подключения к хранилищу',
+      value: existing?.user ?? '',
+      ignoreFocusOut: true,
+    });
+    if (user === undefined) { return undefined; }
+
+    const password = await vscode.window.showInputBox({
+      title: 'Пароль хранилища',
+      prompt: 'Пароль для подключения к хранилищу',
+      password: true,
+      ignoreFocusOut: true,
+    });
+    if (password === undefined) { return undefined; }
+
+    const settings: RepoConnectionSettings = { repoPath, user, dbPath, v8Path };
+
+    const all = this.getAllSettings();
+    all[configRoot] = settings;
+    await this.saveAllSettings(all);
+    await this.secrets.store(PASSWORD_KEY_PREFIX + configRoot, password);
+
+    return settings;
+  }
+
+  private getAllSettings(): Record<string, any> {
+    const config = vscode.workspace.getConfiguration(SETTINGS_SECTION);
+    return config.get<Record<string, any>>('connections', {});
+  }
+
+  private async saveAllSettings(all: Record<string, any>): Promise<void> {
+    const config = vscode.workspace.getConfiguration(SETTINGS_SECTION);
+    await config.update('connections', all, vscode.ConfigurationTarget.Workspace);
+  }
+}

--- a/src/services/RepoLockService.ts
+++ b/src/services/RepoLockService.ts
@@ -1,0 +1,335 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { spawn } from 'child_process';
+import { decode } from 'iconv-lite';
+import { NodeKind } from '../MetadataNode';
+import { NODE_KIND_TO_1C_TYPE, TYPE_1C_TO_NODE_KIND } from './RepoTypeMapping';
+import { RepoConnectionService } from './RepoConnectionService';
+
+export enum RepoLockStatus {
+  Unknown = 0,
+  Free = 1,
+  LockedByMe = 2,
+  LockedByOther = 3,
+}
+
+export interface RepoLockInfo {
+  status: RepoLockStatus;
+  lockedBy?: string;
+}
+
+/**
+ * Сервис управления захватами объектов в хранилище конфигурации 1С.
+ * Взаимодействует через 1cv8.exe DESIGNER.
+ */
+export class RepoLockService {
+  /** configRoot → (objectFullName → RepoLockInfo) */
+  private lockCache = new Map<string, Map<string, RepoLockInfo>>();
+  /** configRoot → текущий пользователь хранилища */
+  private repoUsers = new Map<string, string>();
+
+  constructor(
+    private readonly connectionService: RepoConnectionService,
+    private readonly outputChannel: vscode.OutputChannel
+  ) {}
+
+  /** Проверяет, подключена ли конфигурация к хранилищу */
+  isConnected(configRoot: string): boolean {
+    return this.connectionService.hasSettings(configRoot);
+  }
+
+  /** Получает статус захвата объекта */
+  getLockStatus(configRoot: string, nodeKind: NodeKind, objectName: string): RepoLockStatus {
+    const objectKey = this.buildObjectKey(nodeKind, objectName);
+    if (!objectKey) { return RepoLockStatus.Unknown; }
+
+    const configLocks = this.lockCache.get(configRoot);
+    if (!configLocks) { return RepoLockStatus.Unknown; }
+
+    const info = configLocks.get(objectKey);
+    return info?.status ?? RepoLockStatus.Free;
+  }
+
+  /** Получает информацию о захвате объекта */
+  getLockInfo(configRoot: string, nodeKind: NodeKind, objectName: string): RepoLockInfo | undefined {
+    const objectKey = this.buildObjectKey(nodeKind, objectName);
+    if (!objectKey) { return undefined; }
+
+    const configLocks = this.lockCache.get(configRoot);
+    return configLocks?.get(objectKey);
+  }
+
+  /** Захватывает объект в хранилище */
+  async lockObject(configRoot: string, nodeKind: NodeKind, objectName: string): Promise<boolean> {
+    const objectKey = this.buildObjectKey(nodeKind, objectName);
+    if (!objectKey) { return false; }
+
+    const settings = this.connectionService.getSettings(configRoot);
+    if (!settings) { return false; }
+
+    const password = await this.connectionService.getPassword(configRoot);
+
+    const args = this.buildDesignerArgs(settings, password, [
+      '/ConfigurationRepositoryLock',
+      `-Objects`, objectKey,
+    ]);
+
+    const result = await this.runDesignerCommand(settings.v8Path, args, 'lock');
+    if (result.success) {
+      this.updateLocalCache(configRoot, objectKey, RepoLockStatus.LockedByMe, settings.user);
+    }
+    return result.success;
+  }
+
+  /** Снимает захват объекта в хранилище */
+  async unlockObject(configRoot: string, nodeKind: NodeKind, objectName: string): Promise<boolean> {
+    const objectKey = this.buildObjectKey(nodeKind, objectName);
+    if (!objectKey) { return false; }
+
+    const settings = this.connectionService.getSettings(configRoot);
+    if (!settings) { return false; }
+
+    const password = await this.connectionService.getPassword(configRoot);
+
+    const args = this.buildDesignerArgs(settings, password, [
+      '/ConfigurationRepositoryUnlock',
+      '-Objects', objectKey,
+      '-force',
+    ]);
+
+    const result = await this.runDesignerCommand(settings.v8Path, args, 'unlock');
+    if (result.success) {
+      this.updateLocalCache(configRoot, objectKey, RepoLockStatus.Free);
+    }
+    return result.success;
+  }
+
+  /** Обновляет кэш статусов захватов из отчёта хранилища */
+  async refreshLocks(configRoot: string): Promise<boolean> {
+    const settings = this.connectionService.getSettings(configRoot);
+    if (!settings) { return false; }
+
+    this.repoUsers.set(configRoot, settings.user);
+    const password = await this.connectionService.getPassword(configRoot);
+
+    const reportPath = path.join(os.tmpdir(), `v8vscedit-repo-report-${Date.now()}.txt`);
+
+    const args = this.buildDesignerArgs(settings, password, [
+      '/ConfigurationRepositoryReport', reportPath,
+      '-NBegin', '0',
+    ]);
+
+    const result = await this.runDesignerCommand(settings.v8Path, args, 'report');
+    if (!result.success) { return false; }
+
+    try {
+      const newLocks = this.parseReport(reportPath, settings.user);
+      this.lockCache.set(configRoot, newLocks);
+      return true;
+    } finally {
+      try { fs.unlinkSync(reportPath); } catch { /* ignore */ }
+    }
+  }
+
+  /** Очищает кэш для конфигурации */
+  invalidate(configRoot: string): void {
+    this.lockCache.delete(configRoot);
+    this.repoUsers.delete(configRoot);
+  }
+
+  /** Проверяет, может ли данный тип узла быть захвачен */
+  isLockable(nodeKind: NodeKind): boolean {
+    return nodeKind in NODE_KIND_TO_1C_TYPE;
+  }
+
+  /** Есть ли данные о захватах для конфигурации */
+  hasLockData(configRoot: string): boolean {
+    return this.lockCache.has(configRoot);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Приватные методы
+  // ---------------------------------------------------------------------------
+
+  private buildObjectKey(nodeKind: NodeKind, objectName: string): string | undefined {
+    const type1C = NODE_KIND_TO_1C_TYPE[nodeKind];
+    if (!type1C) { return undefined; }
+    return `${type1C}.${objectName}`;
+  }
+
+  private buildDesignerArgs(
+    settings: { dbPath: string; repoPath: string; user: string },
+    password: string,
+    extraArgs: string[]
+  ): string[] {
+    return [
+      'DESIGNER',
+      `/F${settings.dbPath}`,
+      `/ConfigurationRepositoryF`, settings.repoPath,
+      `/ConfigurationRepositoryN`, settings.user,
+      `/ConfigurationRepositoryP`, password,
+      ...extraArgs,
+    ];
+  }
+
+  private async runDesignerCommand(
+    v8Path: string,
+    args: string[],
+    logPrefix: string
+  ): Promise<{ success: boolean; stdout: string; stderr: string }> {
+    const safeArgs = args.map((a) =>
+      a.startsWith('/ConfigurationRepositoryP')
+        ? '/ConfigurationRepositoryP ****'
+        : a
+    );
+    this.outputChannel.appendLine(`[repo:${logPrefix}] Старт: ${v8Path} ${safeArgs.join(' ')}`);
+
+    return new Promise((resolve) => {
+      // На Windows вызываем 1cv8.exe через PowerShell для корректной кодировки
+      const psCommand = `& '${v8Path}' ${args.map((a) => `'${a.replace(/'/g, "''")}'`).join(' ')}`;
+      const child = spawn('powershell', ['-NoProfile', '-Command', psCommand], {
+        shell: false,
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (chunk: Buffer) => {
+        const text = this.decodeOutput(chunk).trim();
+        if (text) {
+          stdout += text + '\n';
+          this.outputChannel.appendLine(`[repo:${logPrefix}] ${text}`);
+        }
+      });
+
+      child.stderr.on('data', (chunk: Buffer) => {
+        const text = this.decodeOutput(chunk).trim();
+        if (text) {
+          stderr += text + '\n';
+          this.outputChannel.appendLine(`[repo:${logPrefix}][stderr] ${text}`);
+        }
+      });
+
+      child.on('error', (err) => {
+        this.outputChannel.appendLine(`[repo:${logPrefix}][error] ${err.message}`);
+        resolve({ success: false, stdout, stderr: err.message });
+      });
+
+      child.on('close', (code) => {
+        const success = code === 0;
+        if (!success) {
+          this.outputChannel.appendLine(`[repo:${logPrefix}] Код завершения: ${code}`);
+        }
+        resolve({ success, stdout, stderr });
+      });
+    });
+  }
+
+  private decodeOutput(chunk: Buffer): string {
+    const utf8Text = chunk.toString('utf-8');
+    if (process.platform !== 'win32' || !utf8Text.includes('�')) {
+      return utf8Text;
+    }
+    const cp866Text = decode(chunk, 'cp866');
+    const cp1251Text = decode(chunk, 'win1251');
+    return this.pickMostReadable([cp866Text, cp1251Text, utf8Text]);
+  }
+
+  private pickMostReadable(candidates: string[]): string {
+    let best = candidates[0] ?? '';
+    let bestScore = -1;
+    for (const candidate of candidates) {
+      const cyr = (candidate.match(/[А-Яа-яЁё]/g) ?? []).length;
+      const replacement = (candidate.match(/�/g) ?? []).length;
+      const score = cyr * 2 - replacement * 3;
+      if (score > bestScore) {
+        best = candidate;
+        bestScore = score;
+      }
+    }
+    return best;
+  }
+
+  /**
+   * Парсит файл отчёта ConfigurationRepositoryReport.
+   * Ищет строки вида «Захвачено: Пользователь — Справочник.Номенклатура».
+   */
+  private parseReport(reportPath: string, currentUser: string): Map<string, RepoLockInfo> {
+    const locks = new Map<string, RepoLockInfo>();
+
+    if (!fs.existsSync(reportPath)) {
+      return locks;
+    }
+
+    let content: string;
+    try {
+      const raw = fs.readFileSync(reportPath);
+      content = this.decodeOutput(raw);
+    } catch {
+      return locks;
+    }
+
+    // Формат отчёта хранилища содержит строки вида:
+    // «Захвачен - Пользователь "ИмяПользователя"»
+    // и далее перечисление захваченных объектов.
+    // Парсим построчно, ищем блоки захватов.
+    const lines = content.split(/\r?\n/);
+    let currentLocker: string | null = null;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+
+      // Ищем строку с именем пользователя, захватившего объекты
+      // Формат: "Захвачен - Пользователь "ИмяПользователя""
+      const userMatch = trimmed.match(/[Зз]ахвач\S*\s*[-–—]\s*(?:Пользователь\s+)?["«]?([^"»]+)["»]?/i);
+      if (userMatch) {
+        currentLocker = userMatch[1].trim();
+        continue;
+      }
+
+      // Ищем строку с объектом метаданных (ТипОбъекта.ИмяОбъекта)
+      // Проверяем, что это известный тип 1С
+      const objectMatch = trimmed.match(/^(\S+)\.(\S+)$/);
+      if (objectMatch && currentLocker) {
+        const [, typeName, objectName] = objectMatch;
+        const nodeKind = TYPE_1C_TO_NODE_KIND.get(typeName);
+        if (nodeKind) {
+          const key = `${typeName}.${objectName}`;
+          const isMe = currentLocker.toLowerCase() === currentUser.toLowerCase();
+          locks.set(key, {
+            status: isMe ? RepoLockStatus.LockedByMe : RepoLockStatus.LockedByOther,
+            lockedBy: currentLocker,
+          });
+        }
+      }
+
+      // Пустая строка сбрасывает текущего пользователя
+      if (trimmed === '') {
+        currentLocker = null;
+      }
+    }
+
+    return locks;
+  }
+
+  private updateLocalCache(
+    configRoot: string,
+    objectKey: string,
+    status: RepoLockStatus,
+    lockedBy?: string
+  ): void {
+    let configLocks = this.lockCache.get(configRoot);
+    if (!configLocks) {
+      configLocks = new Map();
+      this.lockCache.set(configRoot, configLocks);
+    }
+
+    if (status === RepoLockStatus.Free) {
+      configLocks.delete(objectKey);
+    } else {
+      configLocks.set(objectKey, { status, lockedBy });
+    }
+  }
+}

--- a/src/services/RepoLockService.ts
+++ b/src/services/RepoLockService.ts
@@ -150,6 +150,131 @@ export class RepoLockService {
   }
 
   // ---------------------------------------------------------------------------
+  // Операции с хранилищем
+  // ---------------------------------------------------------------------------
+
+  /** Создаёт новое хранилище конфигурации из базы данных */
+  async createRepository(configRoot: string): Promise<boolean> {
+    const settings = this.connectionService.getSettings(configRoot);
+    if (!settings) { return false; }
+
+    const password = await this.connectionService.getPassword(configRoot);
+
+    const args: string[] = [
+      'DESIGNER',
+      `/F${settings.dbPath}`,
+      '/ConfigurationRepositoryCreate',
+      `-Path`, settings.repoPath,
+      `-User`, settings.user,
+      `-Pwd`, password,
+    ];
+
+    const result = await this.runDesignerCommand(settings.v8Path, args, 'create');
+    return result.success;
+  }
+
+  /**
+   * Помещает изменения конфигурации в хранилище.
+   * @param comment — комментарий к версии
+   * @param objects — если указаны, помещаются только эти объекты; иначе — все изменённые
+   */
+  async commitToRepository(
+    configRoot: string,
+    comment?: string,
+    objects?: Array<{ nodeKind: NodeKind; name: string }>
+  ): Promise<boolean> {
+    const settings = this.connectionService.getSettings(configRoot);
+    if (!settings) { return false; }
+
+    const password = await this.connectionService.getPassword(configRoot);
+
+    const extraArgs: string[] = ['/ConfigurationRepositoryCommit'];
+    if (comment) {
+      extraArgs.push('-comment', comment);
+    }
+    if (objects && objects.length > 0) {
+      const objectKeys = objects
+        .map((o) => this.buildObjectKey(o.nodeKind, o.name))
+        .filter(Boolean) as string[];
+      if (objectKeys.length > 0) {
+        extraArgs.push('-Objects', objectKeys.join(';'));
+      }
+    }
+
+    const args = this.buildDesignerArgs(settings, password, extraArgs);
+    const result = await this.runDesignerCommand(settings.v8Path, args, 'commit');
+    return result.success;
+  }
+
+  /** Получает конфигурацию из хранилища (обновляет конфигурацию БД) */
+  async updateFromRepository(configRoot: string, version?: number): Promise<boolean> {
+    const settings = this.connectionService.getSettings(configRoot);
+    if (!settings) { return false; }
+
+    const password = await this.connectionService.getPassword(configRoot);
+
+    const extraArgs: string[] = ['/ConfigurationRepositoryUpdateCfg'];
+    if (version !== undefined) {
+      extraArgs.push('-v', String(version));
+    }
+    extraArgs.push('-force');
+
+    const args = this.buildDesignerArgs(settings, password, extraArgs);
+    const result = await this.runDesignerCommand(settings.v8Path, args, 'updateCfg');
+    return result.success;
+  }
+
+  /** Добавляет пользователя в хранилище */
+  async addUser(
+    configRoot: string,
+    userName: string,
+    userPassword: string,
+    rights: 'ReadOnly' | 'LockObjects' | 'ManageConfigurationVersions' | 'Administration' = 'LockObjects'
+  ): Promise<boolean> {
+    const settings = this.connectionService.getSettings(configRoot);
+    if (!settings) { return false; }
+
+    const password = await this.connectionService.getPassword(configRoot);
+
+    const extraArgs: string[] = [
+      '/ConfigurationRepositoryAddUser',
+      '-User', userName,
+      '-Pwd', userPassword,
+      '-Rights', rights,
+    ];
+
+    const args = this.buildDesignerArgs(settings, password, extraArgs);
+    const result = await this.runDesignerCommand(settings.v8Path, args, 'addUser');
+    return result.success;
+  }
+
+  /** Получает историю версий хранилища (отчёт) */
+  async getHistory(configRoot: string, versionCount?: number): Promise<string | undefined> {
+    const settings = this.connectionService.getSettings(configRoot);
+    if (!settings) { return undefined; }
+
+    const password = await this.connectionService.getPassword(configRoot);
+    const reportPath = path.join(os.tmpdir(), `v8vscedit-repo-history-${Date.now()}.txt`);
+
+    const extraArgs: string[] = ['/ConfigurationRepositoryReport', reportPath];
+    if (versionCount) {
+      extraArgs.push('-NBegin', String(versionCount));
+    }
+
+    const args = this.buildDesignerArgs(settings, password, extraArgs);
+    const result = await this.runDesignerCommand(settings.v8Path, args, 'history');
+    if (!result.success) { return undefined; }
+
+    try {
+      if (!fs.existsSync(reportPath)) { return undefined; }
+      const raw = fs.readFileSync(reportPath);
+      return this.decodeOutput(raw);
+    } finally {
+      try { fs.unlinkSync(reportPath); } catch { /* ignore */ }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Приватные методы
   // ---------------------------------------------------------------------------
 

--- a/src/services/RepoTypeMapping.ts
+++ b/src/services/RepoTypeMapping.ts
@@ -1,0 +1,62 @@
+import { NodeKind } from '../MetadataNode';
+
+/**
+ * Маппинг NodeKind → имя типа 1С для параметра -Objects команды DESIGNER.
+ * Формат: «ТипОбъекта.ИмяОбъекта», например «Справочник.Номенклатура».
+ * Включены только объекты верхнего уровня, которые можно захватить в хранилище.
+ */
+export const NODE_KIND_TO_1C_TYPE: Partial<Record<NodeKind, string>> = {
+  Subsystem: 'Подсистема',
+  CommonModule: 'ОбщийМодуль',
+  Role: 'Роль',
+  CommonForm: 'ОбщаяФорма',
+  CommonCommand: 'ОбщаяКоманда',
+  CommandGroup: 'ГруппаКоманд',
+  CommonPicture: 'ОбщаяКартинка',
+  CommonTemplate: 'ОбщийМакет',
+  XDTOPackage: 'ПакетXDTO',
+  StyleItem: 'ЭлементСтиля',
+  DefinedType: 'ОпределяемыйТип',
+  Constant: 'Константа',
+  Catalog: 'Справочник',
+  Document: 'Документ',
+  DocumentNumerator: 'НумераторДокументов',
+  Enum: 'Перечисление',
+  InformationRegister: 'РегистрСведений',
+  AccumulationRegister: 'РегистрНакопления',
+  AccountingRegister: 'РегистрБухгалтерии',
+  CalculationRegister: 'РегистрРасчета',
+  Report: 'Отчет',
+  DataProcessor: 'Обработка',
+  BusinessProcess: 'БизнесПроцесс',
+  Task: 'Задача',
+  ExchangePlan: 'ПланОбмена',
+  ChartOfCharacteristicTypes: 'ПланВидовХарактеристик',
+  ChartOfAccounts: 'ПланСчетов',
+  ChartOfCalculationTypes: 'ПланВидовРасчета',
+  DocumentJournal: 'ЖурналДокументов',
+  ScheduledJob: 'РегламентноеЗадание',
+  EventSubscription: 'ПодпискаНаСобытие',
+  HTTPService: 'HTTPСервис',
+  WebService: 'WebСервис',
+  FilterCriterion: 'КритерийОтбора',
+  Sequence: 'Последовательность',
+  SessionParameter: 'ПараметрСеанса',
+  CommonAttribute: 'ОбщийРеквизит',
+  FunctionalOption: 'ФункциональнаяОпция',
+  FunctionalOptionsParameter: 'ПараметрФункциональныхОпций',
+  SettingsStorage: 'ХранилищеНастроек',
+  Style: 'Стиль',
+  WSReference: 'WSСсылка',
+  ExternalDataSource: 'ВнешнийИсточникДанных',
+  IntegrationService: 'СервисИнтеграции',
+  Language: 'Язык',
+};
+
+/**
+ * Обратный маппинг: русское имя типа 1С → NodeKind.
+ * Используется при парсинге отчёта ConfigurationRepositoryReport.
+ */
+export const TYPE_1C_TO_NODE_KIND: Map<string, NodeKind> = new Map(
+  Object.entries(NODE_KIND_TO_1C_TYPE).map(([kind, type]) => [type, kind as NodeKind])
+);


### PR DESCRIPTION
## Summary
- Добавлена интеграция с хранилищем конфигурации 1С через 1cv8.exe DESIGNER
- Подключение/отключение хранилища из контекстного меню корневого узла
- Захват и снятие захвата объектов метаданных из контекстного меню дерева
- Inline-иконки статуса захвата (зелёный/синий/красный замок) — аналогично иконкам поддержки
- Обновление статуса захватов через ConfigurationRepositoryReport
- Поддержка файловых и серверных (TCP) хранилищ
- Пароль хранится в SecretStorage VS Code

## New files
- `src/services/RepoConnectionService.ts` — управление настройками подключения
- `src/services/RepoLockService.ts` — кэш статусов, вызов 1cv8.exe DESIGNER
- `src/services/RepoTypeMapping.ts` — маппинг NodeKind → русские типы 1С
- 6 SVG-иконок (dark/light × free/mine/other)

## Modified files
- `package.json` — 9 новых команд, меню, настройка connections
- `src/extension.ts` — создание сервисов, регистрация команд-индикаторов
- `src/CommandRegistry.ts` — команды connect/disconnect/lock/unlock/refresh
- `src/MetadataTreeProvider.ts` — applyRepoLockDecoration(), tagConfigRoot()
- `src/MetadataNode.ts` — добавлено свойство configRoot

## Test plan
- [ ] Открыть папку с XML-выгрузкой конфигурации
- [ ] ПКМ на корневом узле → «Подключить к хранилищу» → ввести настройки
- [ ] Проверить inline-иконки замков на объектах
- [ ] ПКМ на свободном объекте → «Захватить» → иконка сменилась
- [ ] ПКМ на захваченном → «Снять захват» → иконка вернулась
- [ ] ПКМ → «Обновить статус захватов»
- [ ] Иконки поддержки по-прежнему работают (регрессия)

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)