### PR TITLE
feat: Document Formatting для BSL (#27)

### DIFF
--- a/src/language-server/providers/formatting.ts
+++ b/src/language-server/providers/formatting.ts
@@ -1,0 +1,71 @@
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { TextEdit, DocumentFormattingParams } from 'vscode-languageserver/node';
+
+/** Ключевые слова, увеличивающие отступ (следующая строка +1 уровень) */
+const INDENT_INCREASE =
+  /^\s*(Процедура|Procedure|Функция|Function|Если|If|Для|For|Пока|While|Попытка|Try|Иначе|Else|ИначеЕсли|ElsIf|Исключение|Except|#Область|#Region)\b/i;
+
+/** Ключевые слова, уменьшающие отступ текущей строки (-1 уровень) */
+const INDENT_DECREASE =
+  /^\s*(КонецПроцедуры|EndProcedure|КонецФункции|EndFunction|КонецЕсли|EndIf|КонецЦикла|EndDo|КонецПопытки|EndTry|Иначе|Else|ИначеЕсли|ElsIf|Исключение|Except|#КонецОбласти|#EndRegion)\b/i;
+
+export function provideDocumentFormatting(
+  document: TextDocument,
+  params: DocumentFormattingParams,
+): TextEdit[] {
+  const tabSize = params.options.tabSize ?? 4;
+  const insertSpaces = params.options.insertSpaces ?? false;
+  const indent = insertSpaces ? ' '.repeat(tabSize) : '\t';
+
+  const text = document.getText();
+  const lines = text.split('\n');
+  const edits: TextEdit[] = [];
+  let level = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trimEnd();
+    const content = trimmed.trimStart();
+
+    if (content.length === 0) {
+      // Пустая строка -- убрать trailing whitespace
+      if (line.length > 0 && line !== '\r') {
+        edits.push({
+          range: { start: { line: i, character: 0 }, end: { line: i, character: line.length } },
+          newText: '',
+        });
+      }
+      continue;
+    }
+
+    // Уменьшаем уровень ДО форматирования текущей строки
+    if (INDENT_DECREASE.test(content)) {
+      level = Math.max(0, level - 1);
+    }
+
+    const expectedIndent = indent.repeat(level);
+    const currentIndent = line.slice(0, line.length - line.trimStart().length);
+
+    if (currentIndent !== expectedIndent) {
+      edits.push({
+        range: { start: { line: i, character: 0 }, end: { line: i, character: currentIndent.length } },
+        newText: expectedIndent,
+      });
+    }
+
+    // Убираем trailing whitespace
+    if (trimmed.length < line.length) {
+      edits.push({
+        range: { start: { line: i, character: trimmed.length }, end: { line: i, character: line.length } },
+        newText: '',
+      });
+    }
+
+    // Увеличиваем уровень ПОСЛЕ форматирования текущей строки
+    if (INDENT_INCREASE.test(content)) {
+      level++;
+    }
+  }
+
+  return edits;
+}

--- a/src/language-server/server.ts
+++ b/src/language-server/server.ts
@@ -19,6 +19,7 @@ import { provideHover } from './providers/hover';
 import { provideCompletionItems, invalidateMetaCache } from './providers/completion';
 import { provideDefinition, invalidateDefinitionCache } from './providers/definition';
 import { provideSignatureHelp } from './providers/signatureHelp';
+import { provideDocumentFormatting } from './providers/formatting';
 import { uriToFsPath } from './lspUtils';
 
 const connection = createConnection(ProposedFeatures.all);
@@ -50,6 +51,7 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
 
       hoverProvider: true,
       definitionProvider: true,
+      documentFormattingProvider: true,
       documentSymbolProvider: true,
       foldingRangeProvider: true,
 
@@ -220,6 +222,18 @@ connection.onDefinition(async (params) => {
     return await provideDefinition(doc, params.position, parserService, workspaceRoots, documents);
   } catch {
     return null;
+  }
+});
+
+connection.onDocumentFormatting((params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) {
+    return [];
+  }
+  try {
+    return provideDocumentFormatting(doc, params);
+  } catch {
+    return [];
   }
 });
 


### PR DESCRIPTION
## Summary
- DocumentFormattingProvider для BSL
- Автоматическое выравнивание отступов по ключевым словам
- Поддержка вложенных конструкций (Если/Для/Попытка/Процедура/Область)
- Удаление trailing whitespace
- Настраиваемый размер отступа (табы/пробелы)

Closes #27

## Test plan
- [ ] Format Document (Shift+Alt+F) в .bsl файле — отступы выравниваются
- [ ] Вложенные Если/Для/Попытка — правильные уровни
- [ ] Trailing whitespace удаляется
- [ ] `npm run build` проходит без ошибок

🤖 Generated with [Claude Code](https://claude.com/claude-code)