### PR TITLE
feat: Rename Symbol для BSL (#5)

### DIFF
--- a/src/language-server/providers/rename.ts
+++ b/src/language-server/providers/rename.ts
@@ -1,0 +1,126 @@
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import {
+  WorkspaceEdit,
+  TextEdit,
+  Range,
+  Position,
+} from 'vscode-languageserver/node';
+import { BslParserService } from '../BslParserService';
+import { getWordAtPosition } from '../lspUtils';
+
+/** Паттерн идентификатора BSL (латиница + кириллица + цифры + подчёркивание). */
+const IDENT_PATTERN = /[\wа-яА-ЯёЁ]+/;
+
+/**
+ * Проверяет, можно ли переименовать символ под курсором.
+ * Возвращает range и placeholder (текущее имя).
+ */
+export async function prepareRename(
+  document: TextDocument,
+  position: Position,
+  _parserService: BslParserService,
+): Promise<{ range: Range; placeholder: string } | null> {
+  const wordInfo = getWordAtPosition(document.getText(), position, IDENT_PATTERN);
+  if (!wordInfo) return null;
+
+  // Не переименовываем ключевые слова
+  if (isKeyword(wordInfo.word)) return null;
+
+  return { range: wordInfo.range, placeholder: wordInfo.word };
+}
+
+/**
+ * Выполняет переименование: находит все вхождения идентификатора
+ * в текущем документе и возвращает WorkspaceEdit.
+ */
+export async function provideRename(
+  document: TextDocument,
+  position: Position,
+  newName: string,
+  _parserService: BslParserService,
+): Promise<WorkspaceEdit | null> {
+  const wordInfo = getWordAtPosition(document.getText(), position, IDENT_PATTERN);
+  if (!wordInfo) return null;
+
+  if (isKeyword(wordInfo.word)) return null;
+
+  const oldName = wordInfo.word;
+  const text = document.getText();
+  const edits: TextEdit[] = [];
+
+  // Находим все вхождения как целые слова (регистронезависимо)
+  const linePattern = new RegExp(
+    `(?<![\\wа-яА-ЯёЁ])${escapeRegex(oldName)}(?![\\wа-яА-ЯёЁ])`,
+    'giu',
+  );
+  const lines = text.split('\n');
+
+  for (let lineNum = 0; lineNum < lines.length; lineNum++) {
+    const line = lines[lineNum];
+    // Reset lastIndex for each line
+    const pattern = new RegExp(linePattern.source, linePattern.flags);
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(line)) !== null) {
+      // Пропускаем вхождения внутри строковых литералов и комментариев
+      if (isInsideStringOrComment(line, match.index)) continue;
+
+      edits.push({
+        range: {
+          start: { line: lineNum, character: match.index },
+          end: { line: lineNum, character: match.index + oldName.length },
+        },
+        newText: newName,
+      });
+    }
+  }
+
+  if (edits.length === 0) return null;
+
+  return { changes: { [document.uri]: edits } };
+}
+
+/** Проверяет, находится ли позиция внутри строки или комментария. */
+function isInsideStringOrComment(line: string, pos: number): boolean {
+  // Комментарий: всё после //
+  const commentIdx = findCommentStart(line);
+  if (commentIdx >= 0 && pos >= commentIdx) return true;
+
+  // Строки: внутри кавычек "..."
+  let inString = false;
+  for (let i = 0; i < pos; i++) {
+    if (line[i] === '"') inString = !inString;
+  }
+  return inString;
+}
+
+/** Находит начало однострочного комментария (не внутри строки). */
+function findCommentStart(line: string): number {
+  let inString = false;
+  for (let i = 0; i < line.length - 1; i++) {
+    if (line[i] === '"') inString = !inString;
+    if (!inString && line[i] === '/' && line[i + 1] === '/') return i;
+  }
+  return -1;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const KEYWORDS = new Set([
+  'если', 'if', 'тогда', 'then', 'иначеесли', 'elsif', 'иначе', 'else',
+  'конецесли', 'endif', 'для', 'for', 'каждого', 'each', 'из', 'in',
+  'по', 'to', 'цикл', 'do', 'конеццикла', 'enddo', 'пока', 'while',
+  'попытка', 'try', 'исключение', 'except', 'конецпопытки', 'endtry',
+  'возврат', 'return', 'прервать', 'break', 'продолжить', 'continue',
+  'новый', 'new', 'экспорт', 'export',
+  'процедура', 'procedure', 'конецпроцедуры', 'endprocedure',
+  'функция', 'function', 'конецфункции', 'endfunction',
+  'перем', 'var', 'знач', 'val',
+  'истина', 'true', 'ложь', 'false', 'неопределено', 'undefined', 'null',
+  'и', 'and', 'или', 'or', 'не', 'not',
+]);
+
+function isKeyword(word: string): boolean {
+  return KEYWORDS.has(word.toLowerCase());
+}

--- a/src/language-server/server.ts
+++ b/src/language-server/server.ts
@@ -21,6 +21,7 @@ import { provideDefinition, invalidateDefinitionCache } from './providers/defini
 import { provideSignatureHelp } from './providers/signatureHelp';
 import { provideDocumentFormatting } from './providers/formatting';
 import { provideWorkspaceSymbols, invalidateWorkspaceSymbolCache } from './providers/workspaceSymbols';
+import { provideRename, prepareRename } from './providers/rename';
 import { uriToFsPath } from './lspUtils';
 
 const connection = createConnection(ProposedFeatures.all);
@@ -53,6 +54,9 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
       hoverProvider: true,
       definitionProvider: true,
       documentFormattingProvider: true,
+      renameProvider: {
+        prepareProvider: true,
+      },
       documentSymbolProvider: true,
       workspaceSymbolProvider: true,
       foldingRangeProvider: true,
@@ -228,6 +232,7 @@ connection.onDefinition(async (params) => {
   }
 });
 
+<<<<<<< HEAD
 connection.onDocumentFormatting((params) => {
   const doc = documents.get(params.textDocument.uri);
   if (!doc) {
@@ -245,6 +250,26 @@ connection.onWorkspaceSymbol(async (params) => {
     return await provideWorkspaceSymbols(params.query, workspaceRoots, parserService);
   } catch {
     return [];
+  }
+});
+
+connection.onPrepareRename(async (params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return null;
+  try {
+    return await prepareRename(doc, params.position, parserService);
+  } catch {
+    return null;
+  }
+});
+
+connection.onRenameRequest(async (params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return null;
+  try {
+    return await provideRename(doc, params.position, params.newName, parserService);
+  } catch {
+    return null;
   }
 });
 


### PR DESCRIPTION
## Summary
- RenameProvider с prepareRename для BSL
- Переименование переменных, процедур и функций в текущем документе
- Case-insensitive поиск вхождений с учётом границ слова
- Пропуск вхождений в строковых литералах и комментариях
- Защита от переименования ключевых слов

Closes #5

## Test plan
- [ ] F2 на имени переменной → переименовывает все вхождения
- [ ] F2 на процедуре → переименовывает определение и вызовы
- [ ] F2 на ключевом слове (Если) → отказывает в переименовании
- [ ] Вхождения в строках и комментариях не затрагиваются
- [ ] `npm run build` проходит без ошибок

🤖 Generated with [Claude Code](https://claude.com/claude-code)