### PR TITLE
feat: кросс-модульный Go to Definition (#2)

### DIFF
--- a/src/language-server/providers/definition.ts
+++ b/src/language-server/providers/definition.ts
@@ -5,6 +5,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { TextDocuments } from 'vscode-languageserver/node';
 import { Location, Position } from 'vscode-languageserver/node';
 import { BslParserService } from '../BslParserService';
+import { BslContextService } from '../BslContextService';
 import { getWordAtPosition, nodeToRange, uriToFsPath } from '../lspUtils';
 
 /** Кэш определений: имя (нижний регистр) → Location. Сбрасывается при изменении BSL-файлов. */
@@ -21,6 +22,7 @@ export async function provideDefinition(
   parserService: BslParserService,
   workspaceRoots: string[],
   documents: TextDocuments<TextDocument>,
+  contextService?: BslContextService,
 ): Promise<Location | null> {
   const wordInfo = getWordAtPosition(document.getText(), position, /[\wа-яА-ЯёЁ_]+/);
   if (!wordInfo) {
@@ -29,6 +31,14 @@ export async function provideDefinition(
   const name = wordInfo.word;
 
   await parserService.ensureInit();
+
+  // 0. Проверяем паттерн "Модуль.Метод" — кросс-модульный переход
+  if (contextService) {
+    const crossModuleLoc = await findCrossModuleDefinition(
+      document, position, parserService, contextService,
+    );
+    if (crossModuleLoc) return crossModuleLoc;
+  }
 
   // 1. Текущий документ
   const localLoc = findInText(document.getText(), document.uri, name, parserService);
@@ -139,6 +149,77 @@ async function findBslFiles(dir: string, depth = 0): Promise<string[]> {
     }
   }
   return results;
+}
+
+/**
+ * Проверяет конструкцию «Модуль.Метод» и возвращает Location определения.
+ * Курсор может стоять на имени модуля (→ открыть Module.bsl)
+ * или на имени метода (→ перейти к процедуре/функции в Module.bsl).
+ */
+async function findCrossModuleDefinition(
+  document: TextDocument,
+  position: Position,
+  parserService: BslParserService,
+  contextService: BslContextService,
+): Promise<Location | null> {
+  await contextService.ensureInitialized();
+
+  const text = document.getText();
+  const wordInfo = getWordAtPosition(text, position, /[\wа-яА-ЯёЁ_]+/);
+  if (!wordInfo) return null;
+
+  const word = wordInfo.word;
+  const wordStart = wordInfo.range.start.character;
+  const wordEnd = wordInfo.range.end.character;
+
+  const lines = text.split('\n');
+  const line = lines[position.line] ?? '';
+
+  // Проверяем: есть ли точка слева от слова? (Модуль.Метод — курсор на Метод)
+  const beforeWord = line.slice(0, wordStart);
+  const dotMatch = /([\wа-яА-ЯёЁ_]+)\.\s*$/u.exec(beforeWord);
+
+  if (dotMatch) {
+    const moduleName = dotMatch[1];
+    return await resolveModuleMethod(moduleName, word, parserService, contextService);
+  }
+
+  // Проверяем: есть ли точка справа от слова? (Модуль.Метод — курсор на Модуль)
+  const afterWord = line.slice(wordEnd);
+  if (/^\s*\./.test(afterWord)) {
+    const moduleInfo = contextService.getModuleByName(word);
+    if (moduleInfo?.bslPath) {
+      return {
+        uri: pathToUri(moduleInfo.bslPath),
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Находит определение метода в файле общего модуля.
+ */
+async function resolveModuleMethod(
+  moduleName: string,
+  methodName: string,
+  parserService: BslParserService,
+  contextService: BslContextService,
+): Promise<Location | null> {
+  const moduleInfo = contextService.getModuleByName(moduleName);
+  if (!moduleInfo?.bslPath) return null;
+
+  let text: string;
+  try {
+    text = await fs.promises.readFile(moduleInfo.bslPath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  const uri = pathToUri(moduleInfo.bslPath);
+  return findInText(text, uri, methodName, parserService);
 }
 
 function pathToUri(filePath: string): string {

--- a/src/language-server/server.ts
+++ b/src/language-server/server.ts
@@ -219,7 +219,7 @@ connection.onDefinition(async (params) => {
     return null;
   }
   try {
-    return await provideDefinition(doc, params.position, parserService, workspaceRoots, documents);
+    return await provideDefinition(doc, params.position, parserService, workspaceRoots, documents, contextService);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Go to Definition понимает `ОбщийМодуль.Метод()` — переходит к определению метода
- Ctrl+Click на имени модуля → открывает Module.bsl общего модуля
- Ctrl+Click на имени метода после точки → переходит к процедуре/функции в модуле
- BslContextService передаётся в provideDefinition для доступа к метаданным

Closes #2

## Test plan
- [ ] `ОбщегоНазначения.ПроцедураСуществует` → Ctrl+Click → открывает Module.bsl на строке процедуры
- [ ] Ctrl+Click на `ОбщегоНазначения` (перед точкой) → открывает Module.bsl на строке 1
- [ ] Обычный Go to Definition (без точки) продолжает работать
- [ ] `npm run build` проходит без ошибок

🤖 Generated with [Claude Code](https://claude.com/claude-code)