### PR TITLE
feat: редактирование свойств и удаление объектов (#9, #12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,10 @@
         "icon": "$(search)"
       },
       {
+        "command": "v8vscedit.deleteMetadataObject",
+        "title": "Удалить объект"
+      },
+      {
         "command": "v8vscedit.bslAnalyzer.showMenu",
         "title": "BSL Analyzer: Меню"
       },
@@ -299,6 +303,11 @@
           "command": "v8vscedit.showProperties",
           "when": "view == v8vsceditTree && !(viewItem =~ /-propertiesHidden/)",
           "group": "navigation@9"
+        },
+        {
+          "command": "v8vscedit.deleteMetadataObject",
+          "when": "view == v8vsceditTree && viewItem =~ /^(Catalog|Document|Enum|Report|DataProcessor|InformationRegister|AccumulationRegister|CommonModule|CommonForm|CommonCommand|Role|Subsystem|ExchangePlan|Constant|BusinessProcess|Task|HTTPService|WebService|ScheduledJob|EventSubscription)-hasXml/",
+          "group": "7_modification@1"
         },
         {
           "command": "v8vscedit.showConfigActions",

--- a/src/CommandRegistry.ts
+++ b/src/CommandRegistry.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import { spawn } from 'child_process';
 import { decode } from 'iconv-lite';
 import { MetadataTreeProvider, MetadataQuickPickItem } from './MetadataTreeProvider';
+import { deleteMetadataObject } from './services/MetaObjectDeleter';
 import { MetadataNode } from './MetadataNode';
 import { PropertiesViewProvider } from './views/PropertiesViewProvider';
 import { OnecFileSystemProvider } from './OnecFileSystemProvider';
@@ -673,6 +674,92 @@ export function registerCommands(
         }
       } else {
         vscode.window.showWarningMessage(`Файл не найден: ${xmlPath}`);
+      }
+    })
+  );
+
+  // Удаление объекта метаданных
+  context.subscriptions.push(
+    vscode.commands.registerCommand('v8vscedit.deleteMetadataObject', async (node: NodeArg) => {
+      const metaNode = node as MetadataNode;
+      if (!metaNode?.xmlPath || !metaNode?.label) { return; }
+
+      const objectName = String(metaNode.label);
+      const nodeKind = String(metaNode.nodeKind);
+
+      // Маппинг NodeKind → метатип и папка
+      const FOLDER_MAP: Record<string, { type: string; folder: string }> = {
+        Catalog: { type: 'Catalog', folder: 'Catalogs' },
+        Document: { type: 'Document', folder: 'Documents' },
+        Enum: { type: 'Enum', folder: 'Enums' },
+        Report: { type: 'Report', folder: 'Reports' },
+        DataProcessor: { type: 'DataProcessor', folder: 'DataProcessors' },
+        InformationRegister: { type: 'InformationRegister', folder: 'InformationRegisters' },
+        AccumulationRegister: { type: 'AccumulationRegister', folder: 'AccumulationRegisters' },
+        AccountingRegister: { type: 'AccountingRegister', folder: 'AccountingRegisters' },
+        CalculationRegister: { type: 'CalculationRegister', folder: 'CalculationRegisters' },
+        CommonModule: { type: 'CommonModule', folder: 'CommonModules' },
+        CommonForm: { type: 'CommonForm', folder: 'CommonForms' },
+        CommonCommand: { type: 'CommonCommand', folder: 'CommonCommands' },
+        CommonTemplate: { type: 'CommonTemplate', folder: 'CommonTemplates' },
+        CommonPicture: { type: 'CommonPicture', folder: 'CommonPictures' },
+        Role: { type: 'Role', folder: 'Roles' },
+        Subsystem: { type: 'Subsystem', folder: 'Subsystems' },
+        ExchangePlan: { type: 'ExchangePlan', folder: 'ExchangePlans' },
+        Constant: { type: 'Constant', folder: 'Constants' },
+        BusinessProcess: { type: 'BusinessProcess', folder: 'BusinessProcesses' },
+        Task: { type: 'Task', folder: 'Tasks' },
+        DocumentJournal: { type: 'DocumentJournal', folder: 'DocumentJournals' },
+        ChartOfCharacteristicTypes: { type: 'ChartOfCharacteristicTypes', folder: 'ChartsOfCharacteristicTypes' },
+        ChartOfAccounts: { type: 'ChartOfAccounts', folder: 'ChartsOfAccounts' },
+        ChartOfCalculationTypes: { type: 'ChartOfCalculationTypes', folder: 'ChartsOfCalculationTypes' },
+        HTTPService: { type: 'HTTPService', folder: 'HTTPServices' },
+        WebService: { type: 'WebService', folder: 'WebServices' },
+        ScheduledJob: { type: 'ScheduledJob', folder: 'ScheduledJobs' },
+        EventSubscription: { type: 'EventSubscription', folder: 'EventSubscriptions' },
+        FilterCriterion: { type: 'FilterCriterion', folder: 'FilterCriteria' },
+        SettingsStorage: { type: 'SettingsStorage', folder: 'SettingsStorages' },
+        DocumentNumerator: { type: 'DocumentNumerator', folder: 'DocumentNumerators' },
+        Sequence: { type: 'Sequence', folder: 'Sequences' },
+        DefinedType: { type: 'DefinedType', folder: 'DefinedTypes' },
+        FunctionalOption: { type: 'FunctionalOption', folder: 'FunctionalOptions' },
+      };
+
+      const mapping = FOLDER_MAP[nodeKind];
+      if (!mapping) {
+        vscode.window.showWarningMessage(`Удаление объектов типа "${nodeKind}" не поддерживается.`);
+        return;
+      }
+
+      // Подтверждение
+      const answer = await vscode.window.showWarningMessage(
+        `Удалить ${objectName} (${nodeKind})? Это действие необратимо.`,
+        { modal: true },
+        'Удалить'
+      );
+      if (answer !== 'Удалить') { return; }
+
+      // Найти Configuration.xml
+      const objectXmlDir = path.dirname(metaNode.xmlPath);
+      const objectsDir = path.dirname(objectXmlDir);
+      const configRoot = path.dirname(objectsDir);
+      const configXmlPath = path.join(configRoot, 'Configuration.xml');
+
+      if (!fs.existsSync(configXmlPath)) {
+        vscode.window.showErrorMessage('Не найден Configuration.xml');
+        return;
+      }
+
+      const result = deleteMetadataObject(configXmlPath, mapping.type, objectName, mapping.folder);
+      if (result.success) {
+        if (result.error) {
+          vscode.window.showWarningMessage(result.error);
+        } else {
+          vscode.window.showInformationMessage(`Объект "${objectName}" удалён.`);
+        }
+        reloadEntries();
+      } else {
+        vscode.window.showErrorMessage(result.error ?? 'Ошибка удаления');
       }
     })
   );

--- a/src/services/MetaObjectDeleter.ts
+++ b/src/services/MetaObjectDeleter.ts
@@ -1,0 +1,81 @@
+/**
+ * Удаление объектов метаданных из конфигурации 1С.
+ * Удаляет файлы объекта и ссылку из Configuration.xml.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Удалить объект метаданных из конфигурации.
+ * @param configXmlPath — путь к Configuration.xml
+ * @param metaType — тип объекта (например "Catalog")
+ * @param objectName — имя объекта (например "МойСправочник")
+ * @param folderName — имя папки (например "Catalogs")
+ * @returns true если удалено успешно
+ */
+export function deleteMetadataObject(
+  configXmlPath: string,
+  metaType: string,
+  objectName: string,
+  folderName: string
+): { success: boolean; error?: string } {
+  const configRoot = path.dirname(configXmlPath);
+
+  // 1. Удалить ссылку из Configuration.xml
+  try {
+    let xml = fs.readFileSync(configXmlPath, 'utf-8');
+
+    // Ищем строку <MetaType>ObjectName</MetaType> в <ChildObjects>
+    // Формат: <Catalog>МойСправочник</Catalog>
+    const tagRegex = new RegExp(
+      `\\s*<${metaType}>${escapeRegex(objectName)}</${metaType}>`,
+      'g'
+    );
+
+    const newXml = xml.replace(tagRegex, '');
+    if (newXml === xml) {
+      return {
+        success: false,
+        error: `Объект <${metaType}>${objectName}</${metaType}> не найден в Configuration.xml`,
+      };
+    }
+
+    fs.writeFileSync(configXmlPath, newXml, 'utf-8');
+  } catch (err) {
+    return {
+      success: false,
+      error: `Ошибка обновления Configuration.xml: ${err}`,
+    };
+  }
+
+  // 2. Удалить папку объекта
+  const objectDir = path.join(configRoot, folderName, objectName);
+  try {
+    if (fs.existsSync(objectDir)) {
+      fs.rmSync(objectDir, { recursive: true, force: true });
+    }
+  } catch (err) {
+    // Не критично — ссылка уже удалена из Configuration.xml
+    return {
+      success: true,
+      error: `Ссылка удалена из Configuration.xml, но не удалось удалить папку: ${err}`,
+    };
+  }
+
+  // 3. Удалить XML-файл объекта если он на верхнем уровне (для простых объектов)
+  const objectXml = path.join(configRoot, folderName, `${objectName}.xml`);
+  try {
+    if (fs.existsSync(objectXml)) {
+      fs.unlinkSync(objectXml);
+    }
+  } catch {
+    // Не критично
+  }
+
+  return { success: true };
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/services/MetaXmlWriter.ts
+++ b/src/services/MetaXmlWriter.ts
@@ -1,0 +1,83 @@
+/**
+ * Сервис записи изменений свойств метаданных обратно в XML-файлы.
+ * Использует regex-замену тегов, аналогично тому как ConfigParser читает.
+ */
+
+import * as fs from 'fs';
+
+/**
+ * Обновить значение простого тега в XML-файле.
+ * Заменяет содержимое тега `<TagName>oldValue</TagName>` на `<TagName>newValue</TagName>`.
+ */
+export function updateSimpleTag(
+  xmlPath: string,
+  tagName: string,
+  newValue: string
+): boolean {
+  let xml = fs.readFileSync(xmlPath, 'utf-8');
+
+  // Простой тег: <TagName>value</TagName>
+  const simpleRegex = new RegExp(
+    `(<${tagName}>)(.*?)(</${tagName}>)`,
+    's'
+  );
+
+  if (simpleRegex.test(xml)) {
+    xml = xml.replace(simpleRegex, `$1${escapeXml(newValue)}$3`);
+    fs.writeFileSync(xmlPath, xml, 'utf-8');
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Обновить значение локализованной строки (Synonym, Comment).
+ * Ищет первый v8:content внутри тега и заменяет его содержимое.
+ */
+export function updateLocalizedTag(
+  xmlPath: string,
+  tagName: string,
+  newValue: string
+): boolean {
+  let xml = fs.readFileSync(xmlPath, 'utf-8');
+
+  // Найти блок <TagName>...</TagName>
+  const blockRegex = new RegExp(
+    `(<${tagName}>)([\\s\\S]*?)(</${tagName}>)`
+  );
+  const blockMatch = xml.match(blockRegex);
+  if (!blockMatch) return false;
+
+  const block = blockMatch[2];
+
+  // Заменить первый v8:content
+  const contentRegex = /(<v8:content>)([\s\S]*?)(<\/v8:content>)/;
+  if (contentRegex.test(block)) {
+    const newBlock = block.replace(contentRegex, `$1${escapeXml(newValue)}$3`);
+    xml = xml.replace(blockRegex, `$1${newBlock}$3`);
+    fs.writeFileSync(xmlPath, xml, 'utf-8');
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Обновить булево свойство в блоке <Properties>.
+ */
+export function updateBooleanTag(
+  xmlPath: string,
+  tagName: string,
+  newValue: boolean
+): boolean {
+  return updateSimpleTag(xmlPath, tagName, newValue ? 'true' : 'false');
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/src/views/PropertiesViewProvider.ts
+++ b/src/views/PropertiesViewProvider.ts
@@ -6,10 +6,12 @@ import {
   ObjectPropertyItem,
 } from '../handlers/_types';
 import { getHandlerForNode } from '../handlers';
+import { updateSimpleTag, updateLocalizedTag, updateBooleanTag } from '../services/MetaXmlWriter';
 
 /** Управляет вкладкой свойств объекта метаданных (singleton WebviewPanel) */
 export class PropertiesViewProvider implements vscode.Disposable {
   private panel: vscode.WebviewPanel | undefined;
+  private currentNode: MetadataNode | undefined;
 
   /**
    * Открывает вкладку свойств для узла.
@@ -17,6 +19,8 @@ export class PropertiesViewProvider implements vscode.Disposable {
    * новую группу редактора не создаёт.
    */
   show(node: MetadataNode): void {
+    this.currentNode = node;
+
     if (this.panel) {
       this.panel.title = this.buildTitle(node);
       this.panel.webview.html = this.renderHtml(node);
@@ -26,12 +30,48 @@ export class PropertiesViewProvider implements vscode.Disposable {
         '1cPropertiesView',
         this.buildTitle(node),
         { viewColumn: vscode.ViewColumn.Active, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: false }
+        { enableScripts: true, retainContextWhenHidden: false }
       );
       this.panel.webview.html = this.renderHtml(node);
+
+      // Обработка сообщений от webview
+      this.panel.webview.onDidReceiveMessage((msg) => {
+        this.handleMessage(msg);
+      });
+
       this.panel.onDidDispose(() => {
         this.panel = undefined;
+        this.currentNode = undefined;
       });
+    }
+  }
+
+  private handleMessage(msg: { type: string; key?: string; value?: string | boolean }): void {
+    if (msg.type !== 'updateProperty' || !this.currentNode?.xmlPath || !msg.key) return;
+
+    const xmlPath = this.currentNode.xmlPath;
+    const key = msg.key;
+    const value = msg.value;
+
+    // Определить тип свойства и записать
+    const LOCALIZED_TAGS = new Set(['Synonym', 'Comment', 'ToolTip', 'Explanation']);
+    const BOOLEAN_TAGS = new Set([
+      'PasswordMode', 'MultiLine', 'ExtendedEdit', 'FillFromFillingValue',
+      'CreateOnInput', 'QuickChoice', 'FullTextSearch', 'UseStandardCommands',
+      'IncludeHelpInContents', 'CheckUnique', 'Autonumbering',
+    ]);
+
+    let ok = false;
+    if (LOCALIZED_TAGS.has(key)) {
+      ok = updateLocalizedTag(xmlPath, key, String(value));
+    } else if (BOOLEAN_TAGS.has(key)) {
+      ok = updateBooleanTag(xmlPath, key, value === true || value === 'true');
+    } else {
+      ok = updateSimpleTag(xmlPath, key, String(value));
+    }
+
+    if (ok) {
+      vscode.window.setStatusBarMessage(`Свойство "${key}" сохранено`, 2000);
     }
   }
 
@@ -151,6 +191,7 @@ export class PropertiesViewProvider implements vscode.Disposable {
 </head>
 <body>
   ${content}
+  ${this.getWebviewScript()}
 </body>
 </html>`;
   }
@@ -210,11 +251,22 @@ export class PropertiesViewProvider implements vscode.Disposable {
     `;
   }
 
+  /** Свойства, которые можно редактировать */
+  private static EDITABLE_KEYS = new Set([
+    'Name', 'Synonym', 'Comment', 'ToolTip',
+    'PasswordMode', 'MultiLine', 'ExtendedEdit', 'FillFromFillingValue',
+    'CreateOnInput', 'QuickChoice', 'FullTextSearch', 'UseStandardCommands',
+    'IncludeHelpInContents', 'CheckUnique', 'Autonumbering',
+    'FillChecking', 'Indexing',
+  ]);
+
   /** Формирует HTML значения свойства */
   private renderPropertyValue(property: ObjectPropertyItem): string {
+    const editable = this.currentNode?.xmlPath && PropertiesViewProvider.EDITABLE_KEYS.has(property.key);
+
     switch (property.kind) {
       case 'boolean':
-        return `<div class="checkbox-row"><input class="checkbox" type="checkbox" ${property.value === true ? 'checked' : ''} disabled /></div>`;
+        return `<div class="checkbox-row"><input class="checkbox" type="checkbox" ${property.value === true ? 'checked' : ''} ${editable ? `data-key="${escapeHtml(property.key)}" onchange="onBoolChange(this)"` : 'disabled'} /></div>`;
       case 'enum': {
         const enumValue = property.value as EnumPropertyValue;
         const options = enumValue.allowedValues
@@ -222,7 +274,7 @@ export class PropertiesViewProvider implements vscode.Disposable {
             return `<option value="${escapeHtml(option.value)}" ${option.value === enumValue.current ? 'selected' : ''}>${escapeHtml(option.label)}</option>`;
           })
           .join('');
-        return `<select class="select" disabled>${options}</select>`;
+        return `<select class="select" ${editable ? `data-key="${escapeHtml(property.key)}" onchange="onSelectChange(this)"` : 'disabled'}>${options}</select>`;
       }
       case 'localizedString': {
         const localized = property.value as LocalizedStringValue;
@@ -233,14 +285,31 @@ export class PropertiesViewProvider implements vscode.Disposable {
           .join('');
 
         return `
-          <input class="input" type="text" value="${escapeHtml(localized.presentation)}" readonly />
+          <input class="input" type="text" value="${escapeHtml(localized.presentation)}" ${editable ? `data-key="${escapeHtml(property.key)}" onchange="onTextChange(this)"` : 'readonly'} />
           ${items ? `<div class="property-note">Локализации:</div>${items}` : ''}
         `;
       }
       case 'string':
       default:
-        return `<input class="input" type="text" value="${escapeHtml(String(property.value ?? ''))}" readonly />`;
+        return `<input class="input" type="text" value="${escapeHtml(String(property.value ?? ''))}" ${editable ? `data-key="${escapeHtml(property.key)}" onchange="onTextChange(this)"` : 'readonly'} />`;
     }
+  }
+
+  /** JS для webview — отправка изменений через postMessage */
+  private getWebviewScript(): string {
+    return `
+    <script>
+      const vscode = acquireVsCodeApi();
+      function onTextChange(el) {
+        vscode.postMessage({ type: 'updateProperty', key: el.dataset.key, value: el.value });
+      }
+      function onBoolChange(el) {
+        vscode.postMessage({ type: 'updateProperty', key: el.dataset.key, value: el.checked });
+      }
+      function onSelectChange(el) {
+        vscode.postMessage({ type: 'updateProperty', key: el.dataset.key, value: el.value });
+      }
+    </script>`;
   }
 }
 


### PR DESCRIPTION
## Summary

- **Редактирование свойств (#9)**: панель свойств теперь позволяет менять Name, Synonym, Comment и булевы поля с автосохранением в XML
- **Удаление объектов (#12)**: контекстное меню «Удалить объект» для 20+ типов — удаляет из Configuration.xml и файловую систему

Closes #9, Closes #12

## Test plan

### Свойства (#9)
- [ ] Открыть свойства любого справочника/документа
- [ ] Изменить Синоним → значение сохраняется в XML
- [ ] Изменить булево свойство → сохраняется
- [ ] Readonly поля (Тип, путь к данным) не редактируются

### Удаление (#12)
- [ ] ПКМ на справочнике → «Удалить объект» в меню
- [ ] Подтверждение → объект удалён из дерева и файловой системы
- [ ] Отмена → ничего не происходит
- [ ] Configuration.xml обновлён (объект убран из ChildObjects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Delete Object" command in metadata context menu for quick removal of metadata objects.
  * Enabled direct property editing in the Properties panel for supported metadata fields.
  * Implemented confirmation dialogs for deletion operations with success/error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->