### PR TITLE
feat: команда «Редактировать форму» в контекстном меню (#15)

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,10 @@
         "title": "Открыть модуль"
       },
       {
+        "command": "v8vscedit.openFormEditor",
+        "title": "Редактировать форму"
+      },
+      {
         "command": "v8vscedit.showProperties",
         "title": "Свойства"
       },
@@ -253,6 +257,11 @@
         {
           "command": "v8vscedit.openConstantModule",
           "when": "view == v8vsceditTree && viewItem =~ /^Constant-hasXml/",
+          "group": "navigation@2"
+        },
+        {
+          "command": "v8vscedit.openFormEditor",
+          "when": "view == v8vsceditTree && viewItem =~ /^(CommonForm|Form)-hasXml/",
           "group": "navigation@2"
         },
         {

--- a/src/CommandRegistry.ts
+++ b/src/CommandRegistry.ts
@@ -21,6 +21,7 @@ import {
   getFormModulePathForChild,
   getManagerModulePath,
   getObjectModulePath,
+  getObjectLocationFromXml,
   getServiceModulePath,
 } from './ModulePathResolver';
 
@@ -177,6 +178,37 @@ export function registerCommands(
           : buildFormModuleVirtualUri(xmlPath, String(nodeAny.label ?? ''));
       }
       await openModule(fsp, modulePath, vUri, supportService, xmlPath);
+    })
+  );
+
+  // Открыть визуальный редактор формы
+  context.subscriptions.push(
+    vscode.commands.registerCommand('v8vscedit.openFormEditor', async (node: NodeArg) => {
+      const nodeAny = node as any;
+      const xmlPath = nodeAny?.xmlPath as string | undefined;
+      if (!xmlPath) { return; }
+
+      const isCommonForm = nodeAny?.nodeKind === 'CommonForm';
+      const location = getObjectLocationFromXml(xmlPath);
+      let formXmlPath: string;
+
+      if (isCommonForm) {
+        // Общая форма: <ObjectDir>/Ext/Form.xml
+        formXmlPath = path.join(location.objectDir, 'Ext', 'Form.xml');
+      } else {
+        // Форма объекта: <ObjectDir>/Forms/<FormName>/Ext/Form.xml
+        const formName = String(nodeAny.label ?? '');
+        if (!formName) { return; }
+        formXmlPath = path.join(location.objectDir, 'Forms', formName, 'Ext', 'Form.xml');
+      }
+
+      if (!fs.existsSync(formXmlPath)) {
+        vscode.window.showWarningMessage(`Файл формы не найден: ${formXmlPath}`);
+        return;
+      }
+
+      const uri = vscode.Uri.file(formXmlPath);
+      await vscode.commands.executeCommand('vscode.openWith', uri, 'v8vscedit.formEditor');
     })
   );
 


### PR DESCRIPTION
## Summary
- Добавлен пункт **«Редактировать форму»** в контекстное меню для узлов Form и CommonForm
- Клик → открывает `Ext/Form.xml` через визуальный редактор форм (`v8vscedit.formEditor`)
- Для CommonForm: `<ObjectDir>/Ext/Form.xml`
- Для Form (дочерний элемент): `<ObjectDir>/Forms/<FormName>/Ext/Form.xml`

Зависит от PR #49 (визуальный редактор форм), поэтому base = `feat/issue-25`.

Closes #15

## Test plan
- [ ] ПКМ на форме в дереве → пункт «Редактировать форму» появляется
- [ ] Клик → открывается визуальный редактор формы
- [ ] Для общих форм (CommonForm) тоже работает
- [ ] Если Form.xml не существует — показывается предупреждение

🤖 Generated with [Claude Code](https://claude.com/claude-code)